### PR TITLE
Refactor/lsl response stream

### DIFF
--- a/Assets/Tests/Runtime/BCIControllerBehaviorTests.cs
+++ b/Assets/Tests/Runtime/BCIControllerBehaviorTests.cs
@@ -228,8 +228,7 @@ public class BCIControllerBehaviorTests_WhenSendReceiveMarkers : PlayModeTestRun
         {
             var testDurationRunner = AddCoroutineRunner(DelayForSeconds(6, StopAllCoroutineRunners));
             var sendMarkerRunner = AddCoroutineRunner(WriteMockMarker(AddComponent<LSLMarkerStream>(), testValues.Item1, 1));
-            var behaviorRunner = AddCoroutineRunner(_behavior.ReceiveMarkers());
-
+            
             var selectedIndex = -1;
             for (var i = 0; i < 6; i++)
             {
@@ -241,8 +240,8 @@ public class BCIControllerBehaviorTests_WhenSendReceiveMarkers : PlayModeTestRun
 
             testDurationRunner.StartRun();
             sendMarkerRunner.StartRun();
-            behaviorRunner.StartRun();
-            yield return new WaitWhile(() => behaviorRunner.IsRunning);
+            _behavior.ReceiveMarkers();
+            yield return new WaitWhile(() => testDurationRunner.IsRunning);
 
             Assert.AreEqual(testValues.Item2, selectedIndex);
         }

--- a/Assets/Tests/Runtime/BCIControllerBehaviorTests.cs
+++ b/Assets/Tests/Runtime/BCIControllerBehaviorTests.cs
@@ -206,7 +206,7 @@ namespace BCIEssentials.Tests
         {
             var testDurationSeconds = 6;
             var streamListener = AddComponent<LSLResponseStream>();
-            streamListener.value = "UnityMarkerStream";
+            streamListener.Connect("UnityMarkerStream");
             var streamResponses = new List<string[]>();
 
             var enableStimulusRunner =
@@ -251,12 +251,12 @@ namespace BCIEssentials.Tests
 
         private IEnumerator ListenForMarkerStreams(LSLResponseStream responseStream, List<string[]> responses)
         {
-            responseStream.ResolveResponse();
+            responseStream.Connect();
             yield return new WaitForEndOfFrame();
 
             while (true)
             {
-                var response = responseStream.PullResponse(new string[1], 0);
+                var response = responseStream.GetResponses();
                 if (response.Length > 0 && !response[0].Equals(""))
                 {
                     responses.Add(response);

--- a/Assets/Tests/Runtime/BCIControllerBehaviorTests.cs
+++ b/Assets/Tests/Runtime/BCIControllerBehaviorTests.cs
@@ -164,7 +164,7 @@ namespace BCIEssentials.Tests
         }
     }
 
-    public class BCIControllerBehaviorTests_WhenSendReceiveMarkers : PlayModeTestRunnerBase
+public class BCIControllerBehaviorTests_WhenSendReceiveMarkers : PlayModeTestRunnerBase
     {
         private static (string, int)[] k_WhenReceiveMarkersTestMarkerValues =
         {
@@ -207,21 +207,19 @@ namespace BCIEssentials.Tests
             var testDurationSeconds = 6;
             var streamListener = AddComponent<LSLResponseStream>();
             streamListener.Connect("UnityMarkerStream");
-            var streamResponses = new List<string[]>();
 
             var enableStimulusRunner =
                 AddCoroutineRunner(DelayForSeconds(testDurationSeconds, () => _behavior.stimOn = false));
-            var listenForMarkerRunner = AddCoroutineRunner(ListenForMarkerStreams(streamListener, streamResponses));
             var behaviorSendMarkers = AddCoroutineRunner(_behavior.SendMarkers());
 
             //Run Test
-            listenForMarkerRunner.StartRun();
             enableStimulusRunner.StartRun();
             behaviorSendMarkers.StartRun();
             yield return new WaitWhile(() => behaviorSendMarkers.IsRunning);
 
-            Assert.AreEqual(testDurationSeconds / (_behavior.windowLength + _behavior.interWindowInterval),
-                streamResponses.Count);
+            var markersSent = testDurationSeconds / (_behavior.windowLength + _behavior.interWindowInterval);
+            var responses = streamListener.GetResponses();
+            Assert.AreEqual(responses.Length, markersSent);
         }
 
         [UnityTest]
@@ -247,23 +245,6 @@ namespace BCIEssentials.Tests
             yield return new WaitWhile(() => behaviorRunner.IsRunning);
 
             Assert.AreEqual(testValues.Item2, selectedIndex);
-        }
-
-        private IEnumerator ListenForMarkerStreams(LSLResponseStream responseStream, List<string[]> responses)
-        {
-            responseStream.Connect();
-            yield return new WaitForEndOfFrame();
-
-            while (true)
-            {
-                var response = responseStream.GetResponses();
-                if (response.Length > 0 && !response[0].Equals(""))
-                {
-                    responses.Add(response);
-                }
-
-                yield return new WaitForSecondsRealtime(1 / Application.targetFrameRate);
-            }
         }
 
         private IEnumerator WriteMockMarker(LSLMarkerStream markerStream, string value,

--- a/Assets/Tests/Runtime/ControllerTests.cs
+++ b/Assets/Tests/Runtime/ControllerTests.cs
@@ -244,7 +244,7 @@ namespace BCIEssentials.Tests
         {
             var testDurationSeconds = 6;
             var streamListener = AddComponent<LSLResponseStream>();
-            streamListener.value = "UnityMarkerStream";
+            streamListener.Connect("UnityMarkerStream");
             var streamResponses = new List<string[]>();
 
             var enableStimulusRunner =
@@ -289,12 +289,12 @@ namespace BCIEssentials.Tests
 
         private IEnumerator ListenForMarkerStreams(LSLResponseStream responseStream, List<string[]> responses)
         {
-            responseStream.ResolveResponse();
+            responseStream.Connect();
             yield return new WaitForEndOfFrame();
 
             while (true)
             {
-                var response = responseStream.PullResponse(new string[1], 0);
+                var response = responseStream.GetResponses();
                 if (response.Length > 0 && !response[0].Equals(""))
                 {
                     responses.Add(response);

--- a/Assets/Tests/Runtime/LSLResponseStreamTests.cs
+++ b/Assets/Tests/Runtime/LSLResponseStreamTests.cs
@@ -94,7 +94,7 @@ namespace BCIEssentials.Tests
             _testResponseStream.Disconnect();
             
             Assert.IsFalse(_testResponseStream.Connected);
-            Assert.IsFalse(_testResponseStream.HasPolledResponses);
+            Assert.IsFalse(_testResponseStream.HasStoredResponses);
         }
 
         [UnityTest]
@@ -107,7 +107,7 @@ namespace BCIEssentials.Tests
             _testResponseStream.StartPolling();
             yield return new WaitWhile(()=> writeMarkers.IsRunning);
             
-            Assert.IsTrue(_testResponseStream.HasPolledResponses);
+            Assert.IsTrue(_testResponseStream.HasStoredResponses);
         }
 
         [UnityTest]
@@ -132,13 +132,13 @@ namespace BCIEssentials.Tests
             
             _testMarkerStream.Write("amarkervalue");
             yield return null;
-            var hadResponses = _testResponseStream.HasPolledResponses;
+            var hadResponses = _testResponseStream.HasStoredResponses;
             _testResponseStream.StopPolling();
             yield return null;
             _testMarkerStream.Write("amarkervalue");
             yield return null;
             
-            Assert.AreNotEqual(hadResponses, _testResponseStream.HasPolledResponses);
+            Assert.AreNotEqual(hadResponses, _testResponseStream.HasStoredResponses);
         }
 
         [UnityTest]
@@ -171,7 +171,7 @@ namespace BCIEssentials.Tests
             var responses = _testResponseStream.GetResponses();
             
             Assert.AreEqual(sentMarkers, responses.Length);
-            Assert.False(_testResponseStream.HasPolledResponses);
+            Assert.False(_testResponseStream.HasStoredResponses);
         }
 
         [Test]
@@ -181,11 +181,11 @@ namespace BCIEssentials.Tests
             _testMarkerStream.Write("amarkervalue");
             _testResponseStream.StartPolling();
 
-            var hadResponses = _testResponseStream.HasPolledResponses;
+            var hadResponses = _testResponseStream.HasStoredResponses;
             
             _testResponseStream.ClearPolledResponses();
             
-            Assert.AreNotEqual(hadResponses, _testResponseStream.HasPolledResponses);
+            Assert.AreNotEqual(hadResponses, _testResponseStream.HasStoredResponses);
         }
     }
 }

--- a/Assets/Tests/Runtime/LSLResponseStreamTests.cs
+++ b/Assets/Tests/Runtime/LSLResponseStreamTests.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using BCIEssentials.LSL;
+using BCIEssentials.Tests.Utilities;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using Object = UnityEngine.Object;
+
+namespace BCIEssentials.Tests
+{
+    [TestFixture]
+    public class LSLResponseStreamTests : PlayModeTestRunnerBase
+    {
+        private string _testStreamName;
+        private LSLResponseStream _testResponseStream;
+        private LSLMarkerStream _testMarkerStream;
+        
+        [UnitySetUp]
+        public override IEnumerator TestSetup()
+        {
+            Debug.Log($"<b><color=green>Starting Test Run:</color></b> {TestContext.CurrentContext.Test.Name }");
+            yield return LoadEmptySceneAsync();
+            
+            _testMarkerStream = AddComponent<LSLMarkerStream>();
+            _testMarkerStream.gameObject.name = Guid.NewGuid().ToString();
+            Debug.Log($"marker go name: '{_testMarkerStream.gameObject.name}'");
+            
+            _testMarkerStream.StreamName = "PythonResponse";
+            _testMarkerStream.InitializeStream();
+            
+            _testResponseStream = AddComponent<LSLResponseStream>();
+        }
+
+        [Test]
+        public void WhenConnect_ThenConnected()
+        {
+            _testResponseStream.Connect();
+            
+            Assert.IsTrue(_testResponseStream.Connected);
+        }
+
+        [Test]
+        public void WhenConnectWithTargetStreamName_ThenConnected()
+        {
+            var markerStream = AddComponent<LSLMarkerStream>();
+            markerStream.StreamName = "mystreamname";
+            markerStream.InitializeStream();
+            
+            _testResponseStream.Connect("mystreamname");
+            
+            Assert.IsTrue(_testResponseStream.Connected);
+        }
+
+        [Test]
+        public void WhenConnectAndStreamDoesNotExists_ThenNotConnected()
+        {
+            Object.DestroyImmediate(_testMarkerStream);
+            
+            _testResponseStream.Connect();
+            
+            Assert.IsFalse(_testResponseStream.Connected);
+        }
+
+        [Test]
+        public void WhenConnectedAndConnect_ThenDisconnectThenConnect()
+        {
+            _testResponseStream.Connect();
+            _testResponseStream.Connect();
+            
+            Assert.IsTrue(_testResponseStream.Connected);
+        }
+
+        [Test]
+        public void WhenDisconnect_ThenDisconnected()
+        {
+            _testResponseStream.Connect();
+            
+            _testResponseStream.Disconnect();
+            
+            Assert.IsFalse(_testResponseStream.Connected);
+        }
+
+        [UnityTest]
+        public IEnumerator WhenDisconnectAndWasPolling_ThenDisconnectedAndNoResponses()
+        {
+            var writeMarkers = RepeatForSeconds(() => { _testMarkerStream.Write("amarkervalue"); }, 5);
+            _testResponseStream.Connect();
+            
+            writeMarkers.StartRun();
+            _testResponseStream.StartPolling();
+            yield return new WaitUntil(()=> !writeMarkers.IsRunning);
+            _testResponseStream.Disconnect();
+            
+            Assert.IsFalse(_testResponseStream.Connected);
+            Assert.IsFalse(_testResponseStream.HasPolledResponses);
+        }
+
+        [UnityTest]
+        public IEnumerator WhenStartReceiving_ThenReceiveResponses()
+        {
+            var writeMarkers = RepeatForSeconds(() => { _testMarkerStream.Write("amarkervalue"); }, 5);
+            _testResponseStream.Connect();
+            
+            writeMarkers.StartRun();
+            _testResponseStream.StartPolling();
+            yield return new WaitWhile(()=> writeMarkers.IsRunning);
+            
+            Assert.IsTrue(_testResponseStream.HasPolledResponses);
+        }
+
+        [UnityTest]
+        public IEnumerator WhenStartReceivingWithAction_ThenReceiveResponses()
+        {
+            var writeMarkers = RepeatForSeconds(() => { _testMarkerStream.Write("amarkervalue"); }, 5);
+            var responses = new List<string[]>();
+            _testResponseStream.Connect();
+            
+            _testResponseStream.StartPolling((rs)=> responses.Add(rs));
+            writeMarkers.StartRun();
+            yield return new WaitWhile(()=> writeMarkers.IsRunning);
+            
+            Assert.AreEqual(5, responses.Count);
+        }
+
+        [UnityTest]
+        public IEnumerator WhenStopReceiving_ThenStopReceivingResponses()
+        {
+            _testResponseStream.Connect();
+            _testResponseStream.StartPolling();
+            
+            _testMarkerStream.Write("amarkervalue");
+            yield return null;
+            var hadResponses = _testResponseStream.HasPolledResponses;
+            _testResponseStream.StopPolling();
+            yield return null;
+            _testMarkerStream.Write("amarkervalue");
+            yield return null;
+            
+            Assert.AreNotEqual(hadResponses, _testResponseStream.HasPolledResponses);
+        }
+
+        [UnityTest]
+        public IEnumerator WhenGetResponses_ThenReturnsResponses()
+        {
+            _testResponseStream.Connect();
+            _testMarkerStream.Write("amarkervalue");
+            _testMarkerStream.Write("amarkervalue");
+            _testMarkerStream.Write("amarkervalue");
+            yield return null;
+
+            var responses = _testResponseStream.GetResponses();
+            
+            Assert.AreEqual(3, responses.Length);
+        }
+
+        [UnityTest]
+        public IEnumerator WhenPollingAndGetResponses_ThenReturnsAllAvailableResponses()
+        {
+            _testResponseStream.Connect();
+            _testResponseStream.StartPolling();
+            var sentMarkers = 3;
+            for (int i = 0; i < sentMarkers; i++)
+            {
+                _testMarkerStream.Write("amarkervalue");
+                yield return new WaitForSeconds(_testResponseStream.PollFrequency);
+            }
+            
+            
+            var responses = _testResponseStream.GetResponses();
+            
+            Assert.AreEqual(sentMarkers, responses.Length);
+            Assert.False(_testResponseStream.HasPolledResponses);
+        }
+
+        [Test]
+        public void WhenClearResponses_ThenCurrentResponsesCleared()
+        {
+            _testResponseStream.Connect();
+            _testMarkerStream.Write("amarkervalue");
+            _testResponseStream.StartPolling();
+
+            var hadResponses = _testResponseStream.HasPolledResponses;
+            
+            _testResponseStream.ClearPolledResponses();
+            
+            Assert.AreNotEqual(hadResponses, _testResponseStream.HasPolledResponses);
+        }
+    }
+}

--- a/Assets/Tests/Runtime/LSLResponseStreamTests.cs.meta
+++ b/Assets/Tests/Runtime/LSLResponseStreamTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2e0b8bff790febb418f973739222c044
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Runtime/PlayModeTestRunnerBase.cs
+++ b/Assets/Tests/Runtime/PlayModeTestRunnerBase.cs
@@ -98,6 +98,25 @@ namespace BCIEssentials.Tests.Utilities
         {
             return gameObject.AddComponent<T>();
         }
+        
+        protected static CoroutineRunner RepeatForSeconds(Action onRepeat, int repeatCount, float repeatDelay = 0, Action onComplete = null)
+        {
+            repeatCount = repeatCount > 0 ? repeatCount : 1;
+            repeatDelay = repeatDelay >= 0 ? repeatDelay : 0;
+            
+            IEnumerator Repeater()
+            {
+                int count = 0;
+                while (count < repeatCount)
+                {
+                    onRepeat?.Invoke();
+                    ++count;
+                    yield return new WaitForSeconds(repeatDelay);
+                }
+            }
+            
+            return AddCoroutineRunner(new InClassName(new GameObject(), Repeater(), onComplete));
+        }
 
         protected static CoroutineRunner AddCoroutineRunner(IEnumerator coroutine, Action onComplete = null)
         {

--- a/Packages/com.bci4kids.bciessentials/Runtime/LSL/LSLResponseStream.cs
+++ b/Packages/com.bci4kids.bciessentials/Runtime/LSL/LSLResponseStream.cs
@@ -1,112 +1,234 @@
 using System;
-using UnityEditor;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
 using UnityEngine;
 
 namespace BCIEssentials.LSL
 {
     public class LSLResponseStream : MonoBehaviour, IResponseStream
     {
-        //The predicate by which to recognize the python response stream
-        public string responsePredicate = "name='PythonResponse'";
-        //private string[] responseStrings = {""};
-
-        public StreamInfo[] responseInfo;
-
-        public StreamInlet responseInlet;
-        //public responseInlet  liblsl.StreamInlet(responseInfo[0]);
-        //public liblsl.StreamInlet(responseInfo) responseInlet;
-
-        // responseInlet.open_stream();
-        //TODO: Not make this hardcoded+
-        public string value = "PythonResponse";
-        public int pyRespIndex;
-
-
-        public int ResolveResponse()
+        [SerializeField]
+        [Tooltip("The name of the open stream to pull responses from.")]
+        private string _targetStreamName = "PythonResponse";
+        
+        [SerializeField]
+        [Tooltip("The duration in seconds to reattempt to resolve the target stream.")]
+        [UnityEngine.Range(1, 30)]
+        private double _resolveTimeout;
+        
+        [SerializeField]
+        [Tooltip("The duration in seconds between requests to the target stream for responses.")]
+        [Min(0)]
+        private float _pollFrequency;
+        
+        /// <summary>
+        /// The duration in seconds between requests to the target stream for responses.
+        /// <para>Minimum value is 0.</para>
+        /// </summary>
+        public float PollFrequency
         {
-            // Resolve stream not working, crashes unity, use resolve streams instead and then find a way to pick the right one
-            responseInfo = LSL.resolve_streams();
-            if (responseInfo.Length == 0)
+            get => _pollFrequency;
+            set
             {
-                return -1;
+                _pollFrequency = Mathf.Max(0, value);
             }
+        }
+        
+        /// <summary>
+        /// If the target stream was discovered and available.
+        /// </summary>
+        public bool Connected => _responseInlet is { IsClosed: false };
+        
+        /// <summary>
+        /// If the target stream is being polled for responses.
+        /// </summary>
+        public bool Polling => _receivingMarkers != null;
 
-            for (int i = 0; i < responseInfo.Length; i++)
-            {
-                var responseName = responseInfo[i].name();
-                Debug.Log($"Response info: {responseName} ({i})");
+        /// <summary>
+        /// If responses have been received and stored during polling.
+        /// <see cref="GetResponses"/> does not reset this. 
+        /// </summary>
+        public bool HasPolledResponses => _responses.Count > 0;
+        
+        private StreamInlet _responseInlet;
+        private Coroutine _receivingMarkers;
+        private readonly List<string> _responses = new();
 
-                if (!responseName.Equals(value)) continue;
-                
-                pyRespIndex = i;
-                Debug.Log("Got Python Response");
-                responseInlet = new StreamInlet(responseInfo[i]);
-                Debug.Log("Created the inlet");
+        /// <summary>
+        /// Attempt to resolve the target stream using <see cref="_targetStreamName"/>.
+        /// </summary>
+        /// <returns>Returns true if the target stream was resolved.</returns>
+        public void Connect()
+        {
+            Connect(_targetStreamName);
+        }
+        
+        /// <summary>
+        /// Attempt to resolve the target stream using provided stream name.
+        /// </summary>
+        /// <param name="targetStreamName">The name of the stream to resolve.</param>
+        /// <returns>Returns true if the target stream was resolved.</returns>
+        public void Connect(string targetStreamName)
+        {
+            Disconnect();
 
-                //responseInlet.open_stream();
-                //print("Opened the stream");
-
-                // Try to open the stream, timeout after 2 seconds
-                try
-                {
-                    double timeout = 2.0;
-                    responseInlet.open_stream(timeout);
-                    Debug.Log("Opened the stream successfully");
-                    break;
-                }
-                catch (Exception e)
-                {
-                    Debug.Log(e.Message);
-                }
-            }
-
-            // Tried moving it down here so that it only opens the last Python Response stream, and it still crashes
-            // Aparently this is unnecessary anyway because if the stream is not opened it will be opened implicitly 
-            //double timeout = 2.0;
-            //responseInlet.open_stream(timeout);
-            //print("Opened the stream");
-
-            return 1;
-
+            var streamInfos = LSL.resolve_stream("name", targetStreamName, 0, _resolveTimeout);
+            if (streamInfos.Length <= 0) return;
+            
+            _responseInlet = new StreamInlet(streamInfos[0]);
+            _responseInlet.open_stream();
+            
+            Debug.Log($"Connected to stream: {_responseInlet}");
         }
 
-        //void Start()
-        //{
-        //    StreamInfo streamInfo = new StreamInfo(StreamName, StreamType, 1, liblsl.IRREGULAR_RATE, LSL.channel_format_t.cf_float32);
-
-        //    intlet = new StreamOutlet(streamInfo);
-        //}
-
-        public string[] PullResponse(string[] responseStrings, double timeout)
+        /// <summary>
+        /// Dispose the open stream and clear responses.
+        /// </summary>
+        public void Disconnect()
         {
-            // Try to pull sample
-            try
+            if (Polling)
             {
-                //double timeout = 0.1;
-                double result = responseInlet.pull_sample(responseStrings, timeout);
+                StopPolling();
+            }
+            
+            if (Connected)
+            {
+                _responseInlet?.close_stream();
+                _responseInlet?.Dispose();
+                _responseInlet = null;
+            }
+        }
+
+        /// <summary>
+        /// Begin polling the target stream for responses.
+        /// <para>
+        /// Responses are stored until polling stops, are requested or provided
+        /// to the response callback.
+        /// </para>
+        /// </summary>
+        /// <param name="onResponseCallback">An action to invoke when responses are received.</param>
+        public void StartPolling(Action<string[]> onResponseCallback = null)
+        {
+            if (!Connected)
+            {
+                Debug.LogWarning($"The target stream is unavailable. Try calling the '{nameof(Connect)}' method.");
+                return;
+            }
+
+            StopPolling();
+
+            foreach (var response in GetResponses())
+            {
+                _responses.Add(response);
+            }
+            
+            _receivingMarkers = StartCoroutine(PollForSamples(onResponseCallback));
+        }
+
+        /// <summary>
+        /// Stop polling the target stream for responses.
+        /// </summary>
+        public void StopPolling()
+        {
+            _responses.Clear();
+            if (_receivingMarkers != null)
+            {
+                StopCoroutine(_receivingMarkers);
+                _receivingMarkers = null;
+            }
+        }
+        
+        /// <summary>
+        /// Retrieves all available responses either from the polled
+        /// collection or from the stream directly.
+        /// </summary>
+        /// <returns>Returns an array of stream responses.</returns>
+        public string[] GetResponses()
+        {
+            if (!Connected)
+            {
+                Debug.LogWarning($"The target stream is unavailable. Try calling the '{nameof(Connect)}' method.");
+                return Array.Empty<string>();
+            }
+
+            var responses = new List<string>();
+            
+            if (HasPolledResponses)
+            {
+                foreach (var response in _responses)
+                {
+                    responses.Add(response);
+                }
+                
+                _responses.Clear();
+            }
+            
+            if (!Polling)
+            {
+                var availableSamples = _responseInlet.samples_available();
+                var sample = new[] { "" };
+
+                for (int i = 0; i < availableSamples; i++)
+                {
+                    _responseInlet.pull_sample(sample);
+                    responses.Add(sample[0]);
+                }
+
+                return responses.ToArray();
+            }
+            
+            return responses.ToArray();
+        }
+
+        /// <summary>
+        /// Clear the list of any responses received during polling.
+        /// </summary>
+        public void ClearPolledResponses()
+        {
+            _responses.Clear();
+        }
+        
+        private IEnumerator PollForSamples(Action<string[]> onResponse = null)
+        {
+            Debug.Log($"Started polling stream for samples");
+            while (true)
+            {
+                var responses = new []{""};
+                double result = _responseInlet.pull_sample(responses, 0);
                 if (result != 0)
                 {
-                    //print(result);
-                    for (int i = 0; i < responseStrings.Length; i++)
+                    foreach (var response in responses)
                     {
-                        //print(responseStrings[i]);
+                        _responses.Add(response);
+                    }
+
+                    if (onResponse != null)
+                    {
+                        onResponse.Invoke(responses);
+                        _responses.Clear();
                     }
                 }
-
+                
+                yield return new WaitForSeconds(PollFrequency);
             }
-            catch //(Exception e)
-            {
-                //print(e.Message);
-
-            }
-
-            return responseStrings;
         }
-
     }
 
     public interface IResponseStream
     {
+        public bool Connected { get; }
+        public bool HasPolledResponses { get; }
         
+        public void Connect();
+        public void Connect(string targetStringName);
+        public void Disconnect();
+        
+        public void StartPolling(Action<string[]> onResponse = null);
+        public void StopPolling();
+
+        public string[] GetResponses();
+        public void ClearPolledResponses();
     }
 }

--- a/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Behaviors/BCIControllerBehavior.cs
+++ b/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Behaviors/BCIControllerBehavior.cs
@@ -450,7 +450,7 @@ namespace BCIEssentials.ControllerBehaviors
                 // Receive markers
                 // Pull the python response and add it to the responseStrings array
                 var responseStrings = response.GetResponses();
-                var responseString = responseStrings[0];
+                var responseString = responseStrings.Length > 0 ? responseStrings[0]: string.Empty;
 
                 if (responseString.Equals("ping"))
                 {

--- a/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Behaviors/BCIControllerBehavior.cs
+++ b/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Behaviors/BCIControllerBehavior.cs
@@ -54,14 +54,11 @@ namespace BCIEssentials.ControllerBehaviors
             set { _myTag = value; }
         }
 
-        // Receive markers
-        protected bool receivingMarkers = false;
-
         // Scripts
         [SerializeField] protected MatrixSetup setup;
 
         protected LSLMarkerStream marker;
-        protected LSLResponseStream response;
+        protected LSLResponseStream responseStream;
 
         protected virtual void Start()
         {
@@ -84,7 +81,7 @@ namespace BCIEssentials.ControllerBehaviors
             Application.targetFrameRate = targetFrameRate;
 
             marker = lslMarkerStream;
-            response = lslResponseStream;
+            responseStream = lslResponseStream;
 
             //Setup if required
             if (setupRequired)
@@ -160,9 +157,9 @@ namespace BCIEssentials.ControllerBehaviors
         public void StartStopStimulus()
         {
             // Receive incoming markers
-            if (receivingMarkers == false)
+            if (!responseStream.Polling)
             {
-                StartCoroutine(ReceiveMarkers());
+                ReceiveMarkers();
             }
 
             // Turn off if on
@@ -227,9 +224,9 @@ namespace BCIEssentials.ControllerBehaviors
         public void StartAutomatedTraining()
         {
             // Receive incoming markers
-            if (receivingMarkers == false)
+            if (!responseStream.Polling)
             {
-                StartCoroutine(ReceiveMarkers());
+                ReceiveMarkers();
             }
 
             StartCoroutine(DoTraining());
@@ -238,9 +235,9 @@ namespace BCIEssentials.ControllerBehaviors
         public void StartIterativeTraining()
         {
             // Receive incoming markers
-            if (receivingMarkers == false)
+            if (!responseStream.Polling)
             {
-                StartCoroutine(ReceiveMarkers());
+                ReceiveMarkers();
             }
 
             StartCoroutine(DoIterativeTraining());
@@ -431,55 +428,53 @@ namespace BCIEssentials.ControllerBehaviors
         }
 
         // Coroutine to continuously receive markers
-        public IEnumerator ReceiveMarkers()
+        public void ReceiveMarkers()
         {
-            if (!response.Connected)
+            if (!responseStream.Connected)
             {
-                response.Connect();
+                responseStream.Connect();
             }
 
-            //Set interval at which to receive markers
-            float receiveInterval = 1 / Application.targetFrameRate;
+            if (responseStream.Polling)
+            {
+                responseStream.StopPolling();
+            }
 
             //Ping count
             int pingCount = 0;
-
-            // Receive markers continuously
-            while (true) //TODO: Nothing sets this to false, relies on stopping coroutine instead
+            responseStream.StartPolling(responses =>
             {
-                // Receive markers
-                // Pull the python response and add it to the responseStrings array
-                var responseStrings = response.GetResponses();
-                var responseString = responseStrings.Length > 0 ? responseStrings[0]: string.Empty;
-
-                if (responseString.Equals("ping"))
+                foreach (var response in responses)
                 {
-                    pingCount++;
-                    if (pingCount % 100 == 0)
+                    if (response.Equals("ping"))
                     {
-                        Debug.Log($"Ping Count: {pingCount}");
-                    }
-                }
-                else if (!responseString.Equals(""))
-                {
-                    //Question: Why do we only get here if the first value is good, but are then concerned about all other values?
-                    //Question: Do we get more than once response string?
-                    for (int i = 0; i < responseStrings.Length; i++)
-                    {
-                        Debug.Log($"response : {responseString}");
-                        if (int.TryParse(responseString, out var index) && index < objectList.Count)
+                        pingCount++;
+                        if (pingCount % 100 == 0)
                         {
-                            //Run on selection
-                            objectList[index].GetComponent<SPO>().Select();
+                            Debug.Log($"Ping Count: {pingCount}");
+                        }
+                    }
+                    else if (!response.Equals(""))
+                    {
+                        //Question: Why do we only get here if the first value is good, but are then concerned about all other values?
+                        //Question: Do we get more than once response string?
+                        for (int i = 0; i < responses.Length; i++)
+                        {
+                            Debug.Log($"response : {response}");
+                            if (int.TryParse(response, out var index) && index < objectList.Count)
+                            {
+                                //Run on selection
+                                objectList[index].GetComponent<SPO>().Select();
+                            }
                         }
                     }
                 }
+            });
+        }
 
-                // Wait for the next receive interval
-                yield return new WaitForSecondsRealtime(receiveInterval);
-            }
-
-            Debug.Log("Done receiving markers");
+        public void StopReceivingMarkers()
+        {
+            responseStream.StopPolling();
         }
     }
 }

--- a/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Behaviors/BCIControllerBehavior.cs
+++ b/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Behaviors/BCIControllerBehavior.cs
@@ -158,7 +158,7 @@ namespace BCIEssentials.ControllerBehaviors
         public void StartStopStimulus()
         {
             // Receive incoming markers
-            if (!responseStream.Polling)
+            if (!responseStream.Pulling)
             {
                 ReceiveMarkers();
             }
@@ -225,7 +225,7 @@ namespace BCIEssentials.ControllerBehaviors
         public void StartAutomatedTraining()
         {
             // Receive incoming markers
-            if (!responseStream.Polling)
+            if (!responseStream.Pulling)
             {
                 ReceiveMarkers();
             }
@@ -236,7 +236,7 @@ namespace BCIEssentials.ControllerBehaviors
         public void StartIterativeTraining()
         {
             // Receive incoming markers
-            if (!responseStream.Polling)
+            if (!responseStream.Pulling)
             {
                 ReceiveMarkers();
             }
@@ -436,14 +436,14 @@ namespace BCIEssentials.ControllerBehaviors
                 responseStream.Connect();
             }
 
-            if (responseStream.Polling)
+            if (responseStream.Pulling)
             {
-                responseStream.StopPolling();
+                responseStream.StopPulling();
             }
 
             //Ping count
             int pingCount = 0;
-            responseStream.StartPolling(responses =>
+            responseStream.StartPulling(responses =>
             {
                 foreach (var response in responses)
                 {
@@ -475,7 +475,7 @@ namespace BCIEssentials.ControllerBehaviors
 
         public void StopReceivingMarkers()
         {
-            responseStream.StopPolling();
+            responseStream.StopPulling();
         }
     }
 }

--- a/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Behaviors/BCIControllerBehavior.cs
+++ b/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Behaviors/BCIControllerBehavior.cs
@@ -158,7 +158,7 @@ namespace BCIEssentials.ControllerBehaviors
         public void StartStopStimulus()
         {
             // Receive incoming markers
-            if (!responseStream.Pulling)
+            if (!responseStream.Polling)
             {
                 ReceiveMarkers();
             }
@@ -225,7 +225,7 @@ namespace BCIEssentials.ControllerBehaviors
         public void StartAutomatedTraining()
         {
             // Receive incoming markers
-            if (!responseStream.Pulling)
+            if (!responseStream.Polling)
             {
                 ReceiveMarkers();
             }
@@ -236,7 +236,7 @@ namespace BCIEssentials.ControllerBehaviors
         public void StartIterativeTraining()
         {
             // Receive incoming markers
-            if (!responseStream.Pulling)
+            if (!responseStream.Polling)
             {
                 ReceiveMarkers();
             }
@@ -436,14 +436,14 @@ namespace BCIEssentials.ControllerBehaviors
                 responseStream.Connect();
             }
 
-            if (responseStream.Pulling)
+            if (responseStream.Polling)
             {
-                responseStream.StopPulling();
+                responseStream.StopPolling();
             }
 
             //Ping count
             int pingCount = 0;
-            responseStream.StartPulling(responses =>
+            responseStream.StartPolling(responses =>
             {
                 foreach (var response in responses)
                 {
@@ -475,7 +475,7 @@ namespace BCIEssentials.ControllerBehaviors
 
         public void StopReceivingMarkers()
         {
-            responseStream.StopPulling();
+            responseStream.StopPolling();
         }
     }
 }

--- a/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Behaviors/BCIControllerBehavior.cs
+++ b/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Behaviors/BCIControllerBehavior.cs
@@ -101,6 +101,7 @@ namespace BCIEssentials.ControllerBehaviors
         public void CleanUp()
         {
             setup.DestroyMatrix();
+            responseStream.Disconnect();
             StopAllCoroutines();
         }
 

--- a/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Behaviors/BCIControllerBehavior.cs
+++ b/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Behaviors/BCIControllerBehavior.cs
@@ -433,28 +433,23 @@ namespace BCIEssentials.ControllerBehaviors
         // Coroutine to continuously receive markers
         public IEnumerator ReceiveMarkers()
         {
-            if (receivingMarkers == false)
+            if (!response.Connected)
             {
-                //Get response stream from Python
-                print("Looking for a response stream");
-                int diditwork = response.ResolveResponse();
-                print(diditwork.ToString());
-                receivingMarkers = true;
+                response.Connect();
             }
 
             //Set interval at which to receive markers
             float receiveInterval = 1 / Application.targetFrameRate;
-            float responseTimeout = 0f;
 
             //Ping count
             int pingCount = 0;
 
             // Receive markers continuously
-            while (receivingMarkers) //TODO: Nothing sets this to false, relies on stopping coroutine instead
+            while (true) //TODO: Nothing sets this to false, relies on stopping coroutine instead
             {
                 // Receive markers
                 // Pull the python response and add it to the responseStrings array
-                var responseStrings = response.PullResponse(new[] { "" }, responseTimeout);
+                var responseStrings = response.GetResponses();
                 var responseString = responseStrings[0];
 
                 if (responseString.Equals("ping"))

--- a/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Controllers/Controller.cs
+++ b/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Controllers/Controller.cs
@@ -551,25 +551,19 @@ public class Controller : MonoBehaviour
     // Coroutine to continuously receive markers
     public IEnumerator ReceiveMarkers()
     {
-        if (receivingMarkers == false)
+        if (!response.Connected)
         {
-            //Get response stream from Python
-            print("Looking for a response stream");
-            response = GetComponent<LSLResponseStream>();
-            int diditwork = response.ResolveResponse();
-            print(diditwork.ToString());
-            receivingMarkers = true;
+            response.Connect();
         }
 
         //Set interval at which to receive markers
         float receiveInterval = 1 / refreshRate;
-        float responseTimeout = 0f;
 
         //Ping count
         int pingCount = 0;
 
         // Receive markers continuously
-        while (receivingMarkers)
+        while (true)
         {
             // Receive markers
             // Initialize the default response string
@@ -577,7 +571,7 @@ public class Controller : MonoBehaviour
             string[] responseStrings = defaultResponseStrings;
 
             // Pull the python response and add it to the responseStrings array
-            responseStrings = response.PullResponse(defaultResponseStrings, responseTimeout);
+            responseStrings = response.GetResponses();
 
             // Check if there is 
             bool newResponse = !responseStrings[0].Equals(defaultResponseStrings[0]);

--- a/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Controllers/Controller.cs
+++ b/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Controllers/Controller.cs
@@ -573,10 +573,13 @@ public class Controller : MonoBehaviour
             // Pull the python response and add it to the responseStrings array
             responseStrings = response.GetResponses();
 
-            // Check if there is 
-            bool newResponse = !responseStrings[0].Equals(defaultResponseStrings[0]);
-
-
+            if (responseStrings.Length == 0)
+            {
+                // Wait for the next receive interval
+                yield return new WaitForSecondsRealtime(receiveInterval);
+                continue;
+            }
+            
             if (responseStrings[0] == "ping")
             {
                 pingCount++;

--- a/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Controllers/MIController.cs
+++ b/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Controllers/MIController.cs
@@ -59,31 +59,19 @@ namespace BCIEssentials.Controllers
             // Press T to do automated training
             if (Input.GetKeyDown(KeyCode.T))
             {
-                // Receive incoming markers
-                if (receivingMarkers == false)
-                {
-                    StartCoroutine(ReceiveMarkers());
-                }
-
-                StartCoroutine(DoTraining());
+                StartAutomatedTraining();
             }
 
             // Press I to do Iterative training (MI only)
             if (Input.GetKeyDown(KeyCode.I))
             {
-                // Receive incoming markers
-                if (receivingMarkers == false)
-                {
-                    StartCoroutine(ReceiveMarkers());
-                }
-
-                StartCoroutine(DoIterativeTraining());
+                StartIterativeTraining();
             }
 
             // Press U to do User training, stimulus without BCI
             if (Input.GetKeyDown(KeyCode.U))
             {
-                StartCoroutine(DoUserTraining());
+                StartUserTraining();
             }
 
 

--- a/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Controllers/P300Controller.cs
+++ b/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Controllers/P300Controller.cs
@@ -55,31 +55,19 @@ namespace BCIEssentials.Controllers
             // Press T to do automated training
             if (Input.GetKeyDown(KeyCode.T))
             {
-                // Receive incoming markers
-                if (receivingMarkers == false)
-                {
-                    StartCoroutine(ReceiveMarkers());
-                }
-
-                StartCoroutine(DoTraining());
+                StartAutomatedTraining();
             }
 
             // Press I to do Iterative training (MI only)
             if (Input.GetKeyDown(KeyCode.I))
             {
-                // Receive incoming markers
-                if (receivingMarkers == false)
-                {
-                    StartCoroutine(ReceiveMarkers());
-                }
-
-                StartCoroutine(DoIterativeTraining());
+                StartIterativeTraining();
             }
 
             // Press U to do User training, stimulus without BCI
             if (Input.GetKeyDown(KeyCode.U))
             {
-                StartCoroutine(DoUserTraining());
+                StartUserTraining();
             }
 
 

--- a/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Controllers/SSVEPController.cs
+++ b/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Controllers/SSVEPController.cs
@@ -55,31 +55,19 @@ namespace BCIEssentials.Controllers
             // Press T to do automated training
             if (Input.GetKeyDown(KeyCode.T))
             {
-                // Receive incoming markers
-                if (receivingMarkers == false)
-                {
-                    StartCoroutine(ReceiveMarkers());
-                }
-
-                StartCoroutine(DoTraining());
+                StartAutomatedTraining();
             }
 
             // Press I to do Iterative training (MI only)
             if (Input.GetKeyDown(KeyCode.I))
             {
-                // Receive incoming markers
-                if (receivingMarkers == false)
-                {
-                    StartCoroutine(ReceiveMarkers());
-                }
-
-                StartCoroutine(DoIterativeTraining());
+                StartIterativeTraining();
             }
 
             // Press U to do User training, stimulus without BCI
             if (Input.GetKeyDown(KeyCode.U))
             {
-                StartCoroutine(DoUserTraining());
+                StartUserTraining();
             }
 
 


### PR DESCRIPTION
### Refactoring of `LSLResponseStream`
Goal is to reduce clashes between controllers restarting and registering to the same output stream. Additionally to not initialize new streams or coroutines for each stimulus run.

- Moves control of polling internally and out from controller behaviors
- Added interface for future mocking during tests
- Added documentation to methods and properties
- Refactored controllers to use new polling behavior