### PR TITLE
LSLServiceProvider Method Updates

### DIFF
--- a/Assets/Tests/Runtime/LSL/LSLMarkerProviderTests.cs.meta
+++ b/Assets/Tests/Runtime/LSL/LSLMarkerProviderTests.cs.meta
@@ -1,3 +1,0 @@
-fileFormatVersion: 2
-guid: 8c9e3bc5ec0b4533b65d14bfe675310c
-timeCreated: 1689450260

--- a/Assets/Tests/Runtime/LSL/LSLMarkerProviderTests.cs.meta
+++ b/Assets/Tests/Runtime/LSL/LSLMarkerProviderTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 8c9e3bc5ec0b4533b65d14bfe675310c
+timeCreated: 1689450260

--- a/Packages/com.bci4kids.bciessentials/Runtime/LSL/LSLServiceProvider.cs
+++ b/Packages/com.bci4kids.bciessentials/Runtime/LSL/LSLServiceProvider.cs
@@ -21,8 +21,6 @@ namespace BCIEssentials.LSLFramework
         #endregion
 
         private static readonly Dictionary<string, ILSLMarkerReceiver> _markerReceivers = new();
-        private static readonly Dictionary<string, ILSLMarkerProvider> _markerProviders = new();
-
         #region Marker Receivers
 
         /// <summary>

--- a/Packages/com.bci4kids.bciessentials/Runtime/LSL/LSLServiceProvider.cs
+++ b/Packages/com.bci4kids.bciessentials/Runtime/LSL/LSLServiceProvider.cs
@@ -1,10 +1,11 @@
+using System;
 using System.Collections.Generic;
 using LSL;
 using UnityEngine;
 
 namespace BCIEssentials.LSLFramework
 {
-    public class LSLServiceProvider : MonoBehaviour, ILSLService
+    public class LSLServiceProvider : MonoBehaviour, ILSLService 
     {
         private const string k_StreamIdPredicateFormat = "uid='{0}'";
         private const string k_StreamNamePredicateFormat = "name='{0}'";
@@ -19,7 +20,8 @@ namespace BCIEssentials.LSLFramework
         [SerializeField] private LSLMarkerReceiverSettings _responseStreamSettings = new();
         #endregion
 
-        private static readonly Dictionary<string, LSLMarkerReceiver> _markerReceivers = new();
+        private static readonly Dictionary<string, ILSLMarkerReceiver> _markerReceivers = new();
+        private static readonly Dictionary<string, ILSLMarkerProvider> _markerProviders = new();
 
         #region Marker Receivers
 
@@ -29,7 +31,7 @@ namespace BCIEssentials.LSLFramework
         /// </summary>
         /// <param name="receiver">The <see cref="LSLMarkerReceiver"/> to register</param>
         /// <returns>Returns TRUE if the marker was registered.</returns>
-        public bool RegisterMarkerReceiver(LSLMarkerReceiver receiver)
+        public bool RegisterMarkerReceiver(ILSLMarkerReceiver receiver)
         {
             if (receiver == null)
             {
@@ -47,11 +49,26 @@ namespace BCIEssentials.LSLFramework
         }
 
         /// <summary>
+        /// Check if a Marker Receiver is currently registered with this Service Provider.
+        /// </summary>
+        /// <param name="receiver"></param>
+        /// <returns>TRUE if the receiver is registered</returns>
+        public bool HasRegisteredMarkerReceiver(ILSLMarkerReceiver receiver)
+        {
+            return _markerReceivers.ContainsValue(receiver);
+        }
+        
+        /// <summary>
         /// Retrieve a Marker Receiver using its <see cref="StreamInfo.uid()"/>.
+        /// <para>
+        /// If the service provider does not have a receiver for <param name="uid"></param>
+        /// it will try locate an open stream and create a marker receiver if a
+        /// stream is found.
+        /// </para>
         /// </summary>
         /// <param name="uid">UID for the given stream.</param>
         /// <returns>NULL if no receiver found.</returns>
-        public LSLMarkerReceiver GetMarkerReceiverByUID(string uid)
+        public ILSLMarkerReceiver GetMarkerReceiverByUID(string uid)
         {
             //Try find existing registered
             if (SafeTryGetMarkerReceiver(uid, out var receiver))
@@ -74,10 +91,15 @@ namespace BCIEssentials.LSLFramework
 
         /// <summary>
         /// Retrieve a Marker Receiver using its <see cref="StreamInfo.name()"/>.
+        /// <para>
+        /// Will try locate using a predicate first and if an open stream is found
+        /// then the service provider will check if has a registered Marker Receiver
+        /// and otherwise register it as one.
+        /// </para>
         /// </summary>
         /// <param name="streamName">Name of the stream.</param>
         /// <returns>NULL if no receiver found.</returns>
-        public LSLMarkerReceiver GetMarkerReceiverByName(string streamName)
+        public ILSLMarkerReceiver GetMarkerReceiverByName(string streamName)
         {
             return GetMarkerReceiverByPredicate(string.Format(k_StreamNamePredicateFormat, streamName));
         }
@@ -87,11 +109,16 @@ namespace BCIEssentials.LSLFramework
         /// <para>
         /// See <a href="https://en.wikipedia.org/wiki/XPath">XPath 1.0</a> for predicate formatting.
         /// </para>
+        /// <para>
+        /// If the service provider does not have a receiver for <param name="uid"></param>
+        /// it will try locate an open stream and create a marker receiver if a
+        /// stream is found.
+        /// </para>
         /// </summary>
         /// <param name="predicate">The predicate value to search by.</param>
         /// <example>"source_id='id'"</example>
         /// <returns>NULL if no receiver found.</returns>
-        public LSLMarkerReceiver GetMarkerReceiverByPredicate(string predicate)
+        public ILSLMarkerReceiver GetMarkerReceiverByPredicate(string predicate)
         {
             //Just use LSL predicate searching
             var streamInfo = ResolveStream(predicate);
@@ -113,6 +140,19 @@ namespace BCIEssentials.LSLFramework
 
             return receiver;
         }
+
+        /// <summary>
+        /// Unregister a Marker Receiver from Service Provider.
+        /// </summary>
+        /// <param name="receiver">The Marker Receiver to unregister</param>
+        public void UnregisterMarkerReceiver(ILSLMarkerReceiver receiver)
+        {
+            if (_markerReceivers.ContainsValue(receiver))
+            {
+                _markerReceivers.Remove(receiver.UID);
+                receiver.CleanUp();
+            }
+        }
         
         /// <summary>
         /// Gets a <see cref="LSLMarkerReceiver"/> from the collection.
@@ -121,18 +161,30 @@ namespace BCIEssentials.LSLFramework
         /// <param name="id">The key to use.</param>
         /// <param name="markerReceiver">The <see cref="LSLMarkerReceiver"/> found.</param>
         /// <returns>TRUE if a <see cref="LSLMarkerReceiver"/> was found.</returns>
-        private static bool SafeTryGetMarkerReceiver(string id, out LSLMarkerReceiver markerReceiver)
+        private static bool SafeTryGetMarkerReceiver(string id, out ILSLMarkerReceiver markerReceiver)
         {
-            var hasExisting = _markerReceivers.TryGetValue(id, out markerReceiver);
-
-            if (hasExisting && markerReceiver == null)
+            if (!_markerReceivers.TryGetValue(id, out markerReceiver))
             {
-                _markerReceivers.Remove(id);
                 return false;
             }
 
-            return hasExisting;
+            if (markerReceiver is not MonoBehaviour monoReceiver || monoReceiver != null)
+            {
+                return true;
+            }
+            
+            _markerReceivers.Remove(id);
+            return false;
+
         }
+        
+        private ILSLMarkerReceiver NewMarkerReceiver(StreamInfo streamInfo, LSLMarkerReceiverSettings settings = null)
+        {
+            return new GameObject($"{nameof(LSLMarkerReceiver)}_{streamInfo.uid()}")
+                .AddComponent<LSLMarkerReceiver>()
+                .Initialize(streamInfo, settings);
+        }
+        #endregion
         
         private StreamInfo ResolveStream(string predicate)
         {
@@ -146,13 +198,5 @@ namespace BCIEssentials.LSLFramework
             
             return firstStream;
         }
-
-        private LSLMarkerReceiver NewMarkerReceiver(StreamInfo streamInfo, LSLMarkerReceiverSettings settings = null)
-        {
-            return new GameObject($"{nameof(LSLMarkerReceiver)}_{streamInfo.uid()}")
-                .AddComponent<LSLMarkerReceiver>()
-                .Initialize(streamInfo, settings);
-        }
-        #endregion
     }
 }

--- a/Packages/com.bci4kids.bciessentials/Runtime/LSL/Models/ILSLService.cs
+++ b/Packages/com.bci4kids.bciessentials/Runtime/LSL/Models/ILSLService.cs
@@ -2,12 +2,14 @@ namespace BCIEssentials.LSLFramework
 {
     public interface ILSLService
     {
-        public bool RegisterMarkerReceiver(LSLMarkerReceiver receiver);
+        public bool RegisterMarkerReceiver(ILSLMarkerReceiver receiver);
+        public bool HasRegisteredMarkerReceiver(ILSLMarkerReceiver receiver);
+        
+        public ILSLMarkerReceiver GetMarkerReceiverByUID(string uid);
 
-        public LSLMarkerReceiver GetMarkerReceiverByUID(string uid);
+        public ILSLMarkerReceiver GetMarkerReceiverByName(string streamName);
 
-        public LSLMarkerReceiver GetMarkerReceiverByName(string sessionId);
-
-        public LSLMarkerReceiver GetMarkerReceiverByPredicate(string predicate);
+        public ILSLMarkerReceiver GetMarkerReceiverByPredicate(string predicate);
+        public void UnregisterMarkerReceiver(ILSLMarkerReceiver receiver);
     }
 }

--- a/Packages/com.bci4kids.bciessentials/Samples~/BasicMarkerReceivers/BasicMarkerReceivers.unity
+++ b/Packages/com.bci4kids.bciessentials/Samples~/BasicMarkerReceivers/BasicMarkerReceivers.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
+  m_IndirectSpecularColor: {r: 0.37311953, g: 0.38074014, b: 0.3587274, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -271,7 +271,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &188548917
 GameObject:
@@ -340,37 +340,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 668430248}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &239727557
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 239727558}
-  m_Layer: 0
-  m_Name: ==============
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &239727558
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 239727557}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &299915745
 GameObject:
@@ -616,6 +585,41 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 394002932}
   m_CullTransparentMesh: 1
+--- !u!1 &397464355
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 397464356}
+  m_Layer: 0
+  m_Name: Example Marker Receivers
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &397464356
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 397464355}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 493912747}
+  - {fileID: 405580834}
+  - {fileID: 781907050}
+  - {fileID: 1701491664}
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &405580832
 GameObject:
   m_ObjectHideFlags: 0
@@ -627,7 +631,7 @@ GameObject:
   - component: {fileID: 405580834}
   - component: {fileID: 405580833}
   m_Layer: 0
-  m_Name: MarkerSubscriber (2)
+  m_Name: MarkerReceivers (2)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -659,13 +663,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 405580832}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 7
+  m_Father: {fileID: 397464356}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &428958932
 GameObject:
@@ -869,100 +873,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 469968679}
   m_CullTransparentMesh: 1
---- !u!1 &476342832
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 476342834}
-  - component: {fileID: 476342833}
-  m_Layer: 0
-  m_Name: Directional Light
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!108 &476342833
-Light:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 476342832}
-  m_Enabled: 1
-  serializedVersion: 10
-  m_Type: 1
-  m_Shape: 0
-  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
-  m_Intensity: 1
-  m_Range: 10
-  m_SpotAngle: 30
-  m_InnerSpotAngle: 21.80208
-  m_CookieSize: 10
-  m_Shadows:
-    m_Type: 2
-    m_Resolution: -1
-    m_CustomResolution: -1
-    m_Strength: 1
-    m_Bias: 0.05
-    m_NormalBias: 0.4
-    m_NearPlane: 0.2
-    m_CullingMatrixOverride:
-      e00: 1
-      e01: 0
-      e02: 0
-      e03: 0
-      e10: 0
-      e11: 1
-      e12: 0
-      e13: 0
-      e20: 0
-      e21: 0
-      e22: 1
-      e23: 0
-      e30: 0
-      e31: 0
-      e32: 0
-      e33: 1
-    m_UseCullingMatrixOverride: 0
-  m_Cookie: {fileID: 0}
-  m_DrawHalo: 0
-  m_Flare: {fileID: 0}
-  m_RenderMode: 0
-  m_CullingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_RenderingLayerMask: 1
-  m_Lightmapping: 4
-  m_LightShadowCasterMode: 0
-  m_AreaSize: {x: 1, y: 1}
-  m_BounceIntensity: 1
-  m_ColorTemperature: 6570
-  m_UseColorTemperature: 0
-  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
-  m_UseBoundingSphereOverride: 0
-  m_UseViewFrustumForShadowCasterCull: 1
-  m_ShadowRadius: 0
-  m_ShadowAngle: 0
---- !u!4 &476342834
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 476342832}
-  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
-  m_LocalPosition: {x: -972.52386, y: -385.64746, z: -7.9348373}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2117729035}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
 --- !u!1 &493912745
 GameObject:
   m_ObjectHideFlags: 0
@@ -974,7 +884,7 @@ GameObject:
   - component: {fileID: 493912747}
   - component: {fileID: 493912746}
   m_Layer: 0
-  m_Name: MarkerSubscriber (1)
+  m_Name: MarkerReceivers (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1006,13 +916,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 493912745}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 6
+  m_Father: {fileID: 397464356}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &668430247
 GameObject:
@@ -1045,7 +955,7 @@ Transform:
   - {fileID: 188548920}
   - {fileID: 786048458}
   m_Father: {fileID: 0}
-  m_RootOrder: 1
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &713771258
 GameObject:
@@ -1123,13 +1033,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 713771258}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 972.52386, y: 388.64746, z: 7.9348373}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 2117729035}
-  m_RootOrder: 0
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &732288036
 GameObject:
@@ -1181,7 +1091,7 @@ GameObject:
   - component: {fileID: 781907050}
   - component: {fileID: 781907049}
   m_Layer: 0
-  m_Name: MarkerSubscriber_GetAll
+  m_Name: MarkerReceivers_GetAll
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1199,12 +1109,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: dfb5729fcfd1443ca0be1c64d41c4210, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _provider: {fileID: 1030119075}
+  _lslService: {fileID: 1030119075}
   _streamName: MyStream
   _getOnlyLatest: 0
   _requestButton: {fileID: 1378547622}
   _responseText: {fileID: 106859154}
-  LslMarkerReceiver: {fileID: 0}
 --- !u!4 &781907050
 Transform:
   m_ObjectHideFlags: 0
@@ -1212,13 +1121,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 781907048}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 8
+  m_Father: {fileID: 397464356}
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &786048457
 GameObject:
@@ -1536,7 +1445,7 @@ GameObject:
   - component: {fileID: 925908019}
   - component: {fileID: 925908020}
   m_Layer: 0
-  m_Name: MarkerSender
+  m_Name: Example Marker Provider
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1549,13 +1458,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 925908018}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &925908020
 MonoBehaviour:
@@ -1741,7 +1650,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1039229848
 GameObject:
@@ -2436,7 +2345,7 @@ GameObject:
   - component: {fileID: 1701491664}
   - component: {fileID: 1701491663}
   m_Layer: 0
-  m_Name: MarkerSubscriber_GetLatest
+  m_Name: MarkerReceivers_GetLatest
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -2454,12 +2363,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: dfb5729fcfd1443ca0be1c64d41c4210, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _provider: {fileID: 1030119075}
+  _lslService: {fileID: 1030119075}
   _streamName: MyStream
   _getOnlyLatest: 1
   _requestButton: {fileID: 428958936}
   _responseText: {fileID: 1498297695}
-  LslMarkerReceiver: {fileID: 0}
 --- !u!4 &1701491664
 Transform:
   m_ObjectHideFlags: 0
@@ -2467,44 +2375,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1701491662}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 9
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1792249092
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1792249093}
-  m_Layer: 0
-  m_Name: === Generated Marker Receivers ===
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1792249093
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1792249092}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 1177.7601, y: 472.85855, z: -3.905449}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 10
+  m_Father: {fileID: 397464356}
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1831070819
 GameObject:
@@ -2866,39 +2743,6 @@ RectTransform:
   m_AnchoredPosition: {x: -103.5, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &2117729034
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2117729035}
-  m_Layer: 0
-  m_Name: Scene
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2117729035
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2117729034}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 972.52386, y: 388.64746, z: 7.9348373}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 713771261}
-  - {fileID: 476342834}
-  m_Father: {fileID: 0}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2126444133
 GameObject:
   m_ObjectHideFlags: 0

--- a/Packages/com.bci4kids.bciessentials/Samples~/BasicMarkerReceivers/BasicMarkerSender.cs
+++ b/Packages/com.bci4kids.bciessentials/Samples~/BasicMarkerReceivers/BasicMarkerSender.cs
@@ -3,7 +3,7 @@ using LSL;
 using UnityEngine;
 using UnityEngine.UI;
 
-namespace BCIEssentials.LSL.Samples
+namespace BCIEssentials.LSL.Samples.MarkerReceiverExample
 {
     public class BasicMarkerSender: MonoBehaviour
     {

--- a/Packages/com.bci4kids.bciessentials/Samples~/BasicMarkerReceivers/ExampleManualMarkerReceiver.cs
+++ b/Packages/com.bci4kids.bciessentials/Samples~/BasicMarkerReceivers/ExampleManualMarkerReceiver.cs
@@ -4,12 +4,12 @@ using BCIEssentials.Utilities;
 using UnityEngine;
 using UnityEngine.UI;
 
-namespace BCIEssentials.LSL.Samples
+namespace BCIEssentials.LSL.Samples.MarkerReceiverExample
 {
     public class ExampleManualMarkerReceiver : MonoBehaviour
     {
         [Header("Configuration")]
-        [SerializeField] private LSLServiceProvider _provider;
+        [SerializeField] private LSLServiceProvider _lslService;
         [SerializeField] private string _streamName = "MyStream";
         [SerializeField] private bool _getOnlyLatest;
         
@@ -18,12 +18,12 @@ namespace BCIEssentials.LSL.Samples
         [SerializeField] private Text _responseText;
 
         [Space(20), InspectorReadOnly]
-        public LSLMarkerReceiver LslMarkerReceiver;
+        public ILSLMarkerReceiver LslMarkerReceiver;
 
         private void Start()
         {
             _requestButton.onClick.AddListener(GetResponses);
-            LslMarkerReceiver = _provider.GetMarkerReceiverByName(_streamName);;
+            LslMarkerReceiver = _lslService.GetMarkerReceiverByName(_streamName);
         }
 
         public void GetResponses()

--- a/Packages/com.bci4kids.bciessentials/Samples~/BasicMarkerReceivers/ExampleMarkerSubscriber.cs
+++ b/Packages/com.bci4kids.bciessentials/Samples~/BasicMarkerReceivers/ExampleMarkerSubscriber.cs
@@ -4,7 +4,7 @@ using BCIEssentials.Utilities;
 using UnityEngine;
 using UnityEngine.UI;
 
-namespace BCIEssentials.LSL.Samples
+namespace BCIEssentials.LSL.Samples.MarkerReceiverExample
 {
     public class ExampleMarkerSubscriber : MonoBehaviour, ILSLMarkerSubscriber
     {
@@ -33,7 +33,7 @@ namespace BCIEssentials.LSL.Samples
                 return;
             }
 
-            LslMarkerReceiver = _provider.GetMarkerReceiverByName(_streamName);
+            LslMarkerReceiver = _provider.GetMarkerReceiverByName(_streamName) as LSLMarkerReceiver;
             if (LslMarkerReceiver != null && _subscribeOnStart)
             {
                 Subscribe();

--- a/Packages/com.bci4kids.bciessentials/package.json
+++ b/Packages/com.bci4kids.bciessentials/package.json
@@ -39,7 +39,7 @@
     },
     {
       "displayName": "Basic Marker Receviers Example",
-      "description": "An example on how different types of can be used with the LSLServiceProvider.",
+      "description": "An example on how different types of Marker Receivers can be used with the LSLServiceProvider.",
       "path": "Samples~/BasicMarkerReceivers"
     }
   ]


### PR DESCRIPTION
- `LSLServiceProvider` to use interfaces rather than MonoBehavior class
   - intended to allow custom receiver types register with the service
- Added methods for checking and removing receivers
- Test updates and clean up
- Updated Sample