### PR TITLE
API doc sync

### DIFF
--- a/.github/workflows/push-code-files-to-APIdocs-repository.yml
+++ b/.github/workflows/push-code-files-to-APIdocs-repository.yml
@@ -1,0 +1,30 @@
+name: Push code to APIdocs repo
+# This Github action executes on push to `main`
+# and Pushes the code folder `Packages` to the
+# `APIdocs-for-bci-essentials-unity` repo.
+
+on:
+  push:
+    # branches: ["main"]
+    branches: ["push-code-to-APIdocs"]
+
+jobs:
+  push_code:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout SOURCE repository
+        uses: actions/checkout@v3
+
+      - name: Push code to the `APIdocs` repository
+        uses: nkoppel/push-files-to-another-repository@v1.1.1
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.APIDOCS_SYNC }}
+        with:
+          source-files: 'Packages/'
+          destination-username: 'kirtonBCIlab'
+          destination-repository: 'APIdocs-for-bci-essentials-unity'
+          destination-branch: 'main'
+          destination-directory: './'
+          commit-message: "Copy Packages code directory on push to UPSTREAM/main"
+          commit-email: 'n44412824+anup2ladder@users.noreply.github.com'

--- a/.github/workflows/push-code-files-to-APIdocs-repository.yml
+++ b/.github/workflows/push-code-files-to-APIdocs-repository.yml
@@ -5,8 +5,7 @@ name: Push code to APIdocs repo
 
 on:
   push:
-    # branches: ["main"]
-    branches: ["push-code-to-APIdocs"]
+    branches: ["main"]
 
 jobs:
   push_code:


### PR DESCRIPTION
Set-up a github action that uses the [nkoppel/push-files-to-another-repository](https://github.com/marketplace/actions/copy-files-to-another-repository) action to copy the `Packages` code directory to the [APIdocs-for-bci-essentials-unity](https://github.com/kirtonBCIlab/APIdocs-for-bci-essentials-unity) on push to main of bci-essentials-unity.

This will trigger an action in the downstream `APIdocs-for-bci-essentials-unity` repo that will generate an updated version of API HTML docs