### PR TITLE
Added object IDs for MI single training

### DIFF
--- a/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Behaviors/BCIControllerBehavior.cs
+++ b/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Behaviors/BCIControllerBehavior.cs
@@ -37,6 +37,8 @@ namespace BCIEssentials.ControllerBehaviors
         [Tooltip("Provide an initial set of SPO.")]
         protected List<SPO> _selectableSPOs = new();
 
+        private int __uniqueID = 1;
+
         [SerializeField]
         [Tooltip("Enable BCIController Hotkeys")]
         public bool _hotkeysEnabled = true;
@@ -309,6 +311,14 @@ namespace BCIEssentials.ControllerBehaviors
                         if (!taggedGO.TryGetComponent<SPO>(out var spo) || !spo.Selectable)
                         {
                             continue;
+                        }
+
+                        // Check if the object has a unique ObjectID, 
+                        // if not assign it a unique ID
+                        if (taggedGO.GetComponent<SPO>().ObjectID == 0)
+                        {
+                            taggedGO.GetComponent<SPO>().ObjectID = __uniqueID;
+                            __uniqueID++;
                         }
 
                         _selectableSPOs.Add(spo);

--- a/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Behaviors/MIControllerBehavior.cs
+++ b/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Behaviors/MIControllerBehavior.cs
@@ -145,7 +145,7 @@ namespace BCIEssentials.ControllerBehaviors
                 for (int j = 0; j < (numTrainWindows); j++)
                 {
                     // Send the marker for the window
-                    marker.Write($"mi, 99, {targetID}, {windowLength}");
+                    marker.Write($"mi, 1, {targetID}, {windowLength}");
 
                     yield return new WaitForSecondsRealtime(windowLength);
 

--- a/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Behaviors/MIControllerBehavior.cs
+++ b/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Behaviors/MIControllerBehavior.cs
@@ -14,10 +14,6 @@ namespace BCIEssentials.ControllerBehaviors
         public int numSelectionsBeforeTraining = 3; // How many selections to make before creating the classifier
         public int numSelectionsBetweenTraining = 3; // How many selections to make before updating the classifier
 
-        // Variables related to Single training
-        public float windowLengthSingleTrial = 4.0f; // Length of the window in seconds
-        public int windowCountSingleTrial = 4; // Number of windows in the trial
-
         protected int selectionCounter = 0;
         protected int updateCounter = 0;
 
@@ -122,6 +118,8 @@ namespace BCIEssentials.ControllerBehaviors
         //TODO: Figure out why protected here isn't working, but is for other training types
         public override IEnumerator WhileDoSingleTraining()
         {
+            PopulateObjectList();
+
             // For the time being, only allow single training on a single object
             if (_selectableSPOs.Count > 1)
             {
@@ -140,16 +138,16 @@ namespace BCIEssentials.ControllerBehaviors
                 print($"Running single training on option {targetObject.name}");
 
                 // Get the index of the target object
-                int targetIndex = targetObject.SelectablePoolIndex;
-                print($"Running single training on option {targetIndex}");
+                int targetID = targetObject.ObjectID;
+                print($"Running single training on option {targetID}");
 
                 // For each window in the trial
-                for (int j = 0; j < (windowCountSingleTrial); j++)
+                for (int j = 0; j < (numTrainWindows); j++)
                 {
                     // Send the marker for the window
-                    marker.Write($"mi, 99, {targetIndex}, {windowLengthSingleTrial}");
+                    marker.Write($"mi, 99, {targetID}, {windowLength}");
 
-                    yield return new WaitForSecondsRealtime(windowLengthSingleTrial);
+                    yield return new WaitForSecondsRealtime(windowLength);
 
                     if (shamFeedback)
                     {

--- a/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Controllers/BCIController.cs
+++ b/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Controllers/BCIController.cs
@@ -86,6 +86,7 @@ namespace BCIEssentials.Controllers
             _keyBindings.TryAdd(KeyCode.T, () => { StartTraining(BCITrainingType.Automated);});
             _keyBindings.TryAdd(KeyCode.I, () => { StartTraining(BCITrainingType.Iterative);});
             _keyBindings.TryAdd(KeyCode.U, () => { StartTraining(BCITrainingType.User);});
+            _keyBindings.TryAdd(KeyCode.Semicolon, () => { StartTraining(BCITrainingType.Single);});
 
             //Register Object Selection
             _keyBindings.TryAdd(KeyCode.Alpha0, () => { SelectSPOAtEndOfRun(0); });

--- a/Packages/com.bci4kids.bciessentials/Runtime/Scripts/StimulusObjects/SPO.cs
+++ b/Packages/com.bci4kids.bciessentials/Runtime/Scripts/StimulusObjects/SPO.cs
@@ -40,6 +40,12 @@ namespace BCIEssentials.StimulusObjects
         public int SelectablePoolIndex;
 
         /// <summary>
+        /// Assigned in editor or by the PopulateObjectIDList method, this 
+        /// is a unique identifier for this SPO.
+        /// </summary>
+        public int ObjectID = 0;
+
+        /// <summary>
         /// Request this SPO stimulus to begin.
         /// </summary>
         /// <returns>The time at the beginning of this frame using <see cref="Time.time"/></returns>

--- a/Packages/com.bci4kids.bciessentials/Tests/Runtime/BCIControllerBehaviorTests.cs
+++ b/Packages/com.bci4kids.bciessentials/Tests/Runtime/BCIControllerBehaviorTests.cs
@@ -402,6 +402,20 @@ namespace BCIEssentials.Tests
             Assert.AreEqual(_spos[spoIndex], _behavior.LastSelectedSPO);
         }
 
+        //Setup test to check if the SPO Object ID is correctly unique for objects when PopulateObject method is used
+        [UnityTest]
+        public IEnumerator WhenPopulateObjectList_PopulateUniqueSPOIDs()
+        {
+            //Assert that the SPOs have same ID before Populating Object LIst
+            Assert.AreEqual(_spos[0].ObjectID, _spos[1].ObjectID);
+
+            _behavior.PopulateObjectList();
+            yield return null;
+            //Assert now that the SPO IDs are unique
+            Assert.AreNotEqual(_spos[0].ObjectID, _spos[1].ObjectID);
+
+        }
+
         [UnityTest]
         public IEnumerator WhenSelectSPOAndStopStimulusRun_ThenSPOSelectedAndStimulusRunEnded()
         {

--- a/Packages/com.bci4kids.bciessentials/package.json
+++ b/Packages/com.bci4kids.bciessentials/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.bci4kids.bciessentials",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "displayName": "BCI Essentials",
   "description": "A Unity base environment for streamlined development of BCI applications",
   "unity": "2021.3",

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -3,7 +3,7 @@
     "com.labstreaminglayer.lsl4unity": "https://github.com/labstreaminglayer/LSL4Unity.git",
     "com.unity.collab-proxy": "1.17.7",
     "com.unity.ide.rider": "3.0.17",
-    "com.unity.ide.visualstudio": "2.0.16",
+    "com.unity.ide.visualstudio": "2.0.22",
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.shadergraph": "12.1.8",
     "com.unity.test-framework": "1.3.2",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -42,7 +42,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.visualstudio": {
-      "version": "2.0.16",
+      "version": "2.0.22",
       "depth": 0,
       "source": "registry",
       "dependencies": {


### PR DESCRIPTION
Populate object list now assigns a unique ID if an SPO doesn't already have one. 

Single training uses the unique ID as the label for python instead of the index.