### PR TITLE
Build cleanups

### DIFF
--- a/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Utilities/ArrayUtilities.cs
+++ b/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Utilities/ArrayUtilities.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using PlasticPipe.PlasticProtocol.Messages;
 
 namespace BCIEssentials.Utilities
 {

--- a/Packages/com.bci4kids.bciessentials/package.json
+++ b/Packages/com.bci4kids.bciessentials/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.bci4kids.bciessentials",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "displayName": "BCI Essentials",
   "description": "A Unity base environment for streamlined development of BCI applications",
   "unity": "2021.3",


### PR DESCRIPTION
Removing a spurious import that causes build to fail.

Tested with a fresh project, import lsl + bessy, do a build.  Works.