### PR TITLE
Ekl RNRA Fix - Using Fisher-Yates

### DIFF
--- a/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Behaviors/BCIControllerBehavior.cs
+++ b/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Behaviors/BCIControllerBehavior.cs
@@ -582,7 +582,7 @@ namespace BCIEssentials.ControllerBehaviors
             int numOptions = _selectableSPOs.Count;
 
             // Create a random non repeating array 
-            int[] trainArray = ArrayUtilities.GenerateRNRA(numTrainingSelections, 0, numOptions);
+            int[] trainArray = ArrayUtilities.GenerateRNRA_FisherYates(numTrainingSelections, 0, numOptions-1);
             LogArrayValues(trainArray);
 
             yield return new WaitForSecondsRealtime(0.001f);

--- a/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Behaviors/BCIControllerBehavior.cs
+++ b/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Behaviors/BCIControllerBehavior.cs
@@ -65,7 +65,7 @@ namespace BCIEssentials.ControllerBehaviors
         [Header("BCI Training Properties")]
         [Tooltip("The number of training iterations")]
         public int numTrainingSelections;
-        [Tooltip("The number of windows used in each training iteration")]
+        [Tooltip("The number of windows used in each training iteration. This does nothing for P300.")]
         public int numTrainWindows = 3;
         [Tooltip("Before training starts, pause for this amount of time")]
         public float pauseBeforeTraining = 2;

--- a/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Behaviors/BCIControllerBehavior.cs
+++ b/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Behaviors/BCIControllerBehavior.cs
@@ -19,7 +19,7 @@ namespace BCIEssentials.ControllerBehaviors
         /// The type of BCI behavior implemented.
         /// </summary>
         public abstract BCIBehaviorType BehaviorType { get; }
-
+        [Header("BCI Registration")]
         [SerializeField]
         [Tooltip("Register and Unregister with the BCI Controller instance using Start and OnDestroy")]
         private bool _selfRegister = true;
@@ -27,46 +27,64 @@ namespace BCIEssentials.ControllerBehaviors
         [SerializeField]
         [Tooltip("Whether to set as active behavior when self registering.")]
         private bool _selfRegisterAsActive;
+
+        [Header("Default SPO Setup")]
+        [Tooltip("Component used to set-up default SPO objects")]
+        [SerializeField] protected MatrixSetup setup;
+        [Tooltip("Indicate whether or not to use the setup component")]
+        public bool setupRequired;
         
+        [Header("System Properties and Targets")]
         [SerializeField]
         [Tooltip("The applications target frame rate. 0 results in no override being applied. -1 or higher than 0 is still applied.")]
         [Min(-1)]
         protected int targetFrameRate = 60;
 
         [SerializeField]
+        [Tooltip("Enable BCIController Hotkeys")]
+        public bool _hotkeysEnabled = true;
+
+        [Header("SPO Objects")]
+        [SerializeField]
         [Tooltip("Provide an initial set of SPO.")]
         protected List<SPO> _selectableSPOs = new();
 
         private int __uniqueID = 1;
 
-        [SerializeField]
-        [Tooltip("Enable BCIController Hotkeys")]
-        public bool _hotkeysEnabled = true;
-
-
         #region Refactorable Properties
 
+        [Header("BCI Signal Properties")]
         //StimulusOn/Off + sending Markers
+        [Tooltip("The length of the processing window")]
+        //TODO: Rename this more appropriately to our Epoch/scheme
         public float windowLength = 1.0f;
+        [Tooltip("The interval between processing windows")]
         public float interWindowInterval = 0f;
 
         //Training
-        [SerializeField] protected MatrixSetup setup;
-        public bool setupRequired;
+        [Header("BCI Training Properties")]
+        [Tooltip("The number of training iterations")]
         public int numTrainingSelections;
+        [Tooltip("The number of windows used in each training iteration")]
         public int numTrainWindows = 3;
+        [Tooltip("Before training starts, pause for this amount of time")]
         public float pauseBeforeTraining = 2;
-        public bool trainTargetPersistent = false;
+        [Tooltip("The time the target is displayed for, before the sequence begins")]
         public float trainTargetPresentationTime = 3f;
         public float trainBreak = 1f;
+        [Tooltip("If true, the train target will pretend to be selected")]
         public bool shamFeedback = false;
+        [Tooltip("If true, the train target will remain in the 'target displayed' state")]
+        public bool trainTargetPersistent = false;
+        [Tooltip("The target object to train on, defaulted to a random high number")]
         public int trainTarget = 99;
 
+        [Header("BCI Training Tag")]
         [FormerlySerializedAs("_myTag")]
         public string myTag = "BCI";
 
         #endregion
-
+        
         /// <summary>
         /// If a stimulus run is currently taking place.
         /// </summary>

--- a/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Behaviors/MIControllerBehavior.cs
+++ b/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Behaviors/MIControllerBehavior.cs
@@ -71,7 +71,7 @@ namespace BCIEssentials.ControllerBehaviors
 
             // Create a random non repeating array 
             int[] trainArray = new int[numTrainingSelections];
-            trainArray = ArrayUtilities.GenerateRNRA(numTrainingSelections, 0, numOptions);
+            trainArray = ArrayUtilities.GenerateRNRA_FisherYates(numTrainingSelections, 0, numOptions-1);
             LogArrayValues(trainArray);
 
             yield return 0;

--- a/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Behaviors/P300ControllerBehavior.cs
+++ b/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Behaviors/P300ControllerBehavior.cs
@@ -12,7 +12,11 @@ namespace BCIEssentials.ControllerBehaviors
     public class P300ControllerBehavior : BCIControllerBehavior
     {
         public override BCIBehaviorType BehaviorType => BCIBehaviorType.P300;
+
+        [Header("P300 Training Properties")]
+        public float trainBufferTime = 0f;
         
+        [Header("P300 Pattern Flashing Properties")]
         public int numFlashesLowerLimit = 9;
         public int numFlashesUpperLimit = 12;
         public Random randNumFlashes = new Random();
@@ -21,29 +25,42 @@ namespace BCIEssentials.ControllerBehaviors
         public float onTime = 0.2f;
         public float offTime = 0.3f;
 
+        [Header("Stimulus Flash Paradigm")]
+        [Tooltip("If true, only one SPO will flash at a time")]
         public bool singleFlash = true;
+        [Tooltip("If true, enables multiple SPOs to flash at the same time." +
+        "Needs to be true for rowColumn and checkerboard to work")]
         public bool multiFlash = false;
-
+        [Tooltip("If true, flashes objects in rows and columns. Requires Multiflash to be true")]
         public bool rowColumn = false;
+        [Tooltip("If true, flashes objects in a checkerboard pattern. Requires Multiflash to be true")]
         public bool checkerboard = true;
-        public int checkerBoardRows = 5;
+
+        [Header("Checkerboard Properties")]
+        [Tooltip("Number of columns in the checkerboard")]
         public int checkerBoardCols = 6;
+        [Tooltip("Number of rows in the checkerboard")]
+        public int checkerBoardRows = 5;
+
 
         public enum multiFlashMethod
         {
             Random
         };
 
+
+
         private float timeOfFlash = 0;
         private float timeOfWrite = 0;
         private float oldTimeOfWrite = 0;
         private float timeLag = 0;
 
+        [Header("Debugging Parameters")]
         public bool timeDebug = false;
 
         private bool blockOutGoingLSL = false;
 
-        public float trainBufferTime = 0f;
+
 
 
         protected override IEnumerator WhileDoAutomatedTraining()
@@ -57,9 +74,13 @@ namespace BCIEssentials.ControllerBehaviors
             // Get number of selectable objects by counting the objects in the objectList
             int numOptions = _selectableSPOs.Count;
 
+            // See how performant the Fisher-Yates shuffle is
+            var watch = System.Diagnostics.Stopwatch.StartNew();
             // Create a random non repeating array 
             int[] trainArray = ArrayUtilities.GenerateRNRA_FisherYates(numTrainingSelections, 0, numOptions-1);
             LogArrayValues(trainArray);
+            watch.Stop();
+            Debug.Log("Fisher-Yates shuffle took " + watch.ElapsedMilliseconds.ToString() + " milliseconds");
             // int[] weightedTrainArray = ArrayUtilities.GenerateWeightedArray(numTrainingSelections, 0, numOptions-1);
             // LogArrayValues(weightedTrainArray);
             // int[] fisherArray = ArrayUtilities.GenerateRNRA_FisherYates(numTrainingSelections, 0, numOptions-1);

--- a/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Behaviors/P300ControllerBehavior.cs
+++ b/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Behaviors/P300ControllerBehavior.cs
@@ -58,8 +58,12 @@ namespace BCIEssentials.ControllerBehaviors
             int numOptions = _selectableSPOs.Count;
 
             // Create a random non repeating array 
-            int[] trainArray = ArrayUtilities.GenerateRNRA(numTrainingSelections, 0, numOptions);
+            int[] trainArray = ArrayUtilities.GenerateRNRA_FisherYates(numTrainingSelections, 0, numOptions-1);
             LogArrayValues(trainArray);
+            // int[] weightedTrainArray = ArrayUtilities.GenerateWeightedArray(numTrainingSelections, 0, numOptions-1);
+            // LogArrayValues(weightedTrainArray);
+            // int[] fisherArray = ArrayUtilities.GenerateRNRA_FisherYates(numTrainingSelections, 0, numOptions-1);
+            // LogArrayValues(fisherArray);
 
             yield return null;
 
@@ -204,7 +208,7 @@ namespace BCIEssentials.ControllerBehaviors
             if (singleFlash)
             {
                 int totalFlashes = numFlashesPerObjectPerSelection * _selectableSPOs.Count;
-                int[] stimOrder = ArrayUtilities.GenerateRNRA(totalFlashes, 0, _selectableSPOs.Count);
+                int[] stimOrder = ArrayUtilities.GenerateRNRA_FisherYates(totalFlashes, 0, _selectableSPOs.Count-1);
 
                 for (int i = 0; i < stimOrder.Length; i++)
                 {
@@ -295,8 +299,8 @@ namespace BCIEssentials.ControllerBehaviors
                     int totalRowFlashes = numFlashesPerObjectPerSelection * numRows;
 
                     // Create a random order to flash rows and columns
-                    int[] columnStimOrder = ArrayUtilities.GenerateRNRA(totalColumnFlashes, 0, numColumns);
-                    int[] rowStimOrder = ArrayUtilities.GenerateRNRA(totalRowFlashes, 0, numRows);
+                    int[] columnStimOrder = ArrayUtilities.GenerateRNRA_FisherYates(totalColumnFlashes, 0, numColumns-1);
+                    int[] rowStimOrder = ArrayUtilities.GenerateRNRA_FisherYates(totalRowFlashes, 0, numRows-1);
 
                     for (int i = 0; i < totalColumnFlashes; i++)
                     {

--- a/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Behaviors/P300ControllerBehavior.cs
+++ b/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Behaviors/P300ControllerBehavior.cs
@@ -36,11 +36,11 @@ namespace BCIEssentials.ControllerBehaviors
         [Tooltip("If true, flashes objects in a checkerboard pattern. Requires Multiflash to be true")]
         public bool checkerboard = true;
 
-        [Header("Checkerboard Properties")]
-        [Tooltip("Number of columns in the checkerboard")]
-        public int checkerBoardCols = 6;
-        [Tooltip("Number of rows in the checkerboard")]
-        public int checkerBoardRows = 5;
+        [Header("Row/Column & Checkerboard Properties")]
+        [Tooltip("Number of columns in the multi-flash RowColumn or Checkerboard")]
+        public int numFlashColumns = 6;
+        [Tooltip("Number of rows in multi-flash RowColumn or Checkerboard")]
+        public int numFlashRows = 5;
 
 
         public enum multiFlashMethod
@@ -293,10 +293,10 @@ namespace BCIEssentials.ControllerBehaviors
             {
                 // For multi flash selection, create virtual rows and columns
                 int numSelections = _selectableSPOs.Count;
-                int numColumns = (int)Math.Ceiling(Math.Sqrt((float)numSelections));
-                int numRows = (int)Math.Ceiling((float)numSelections / (float)numColumns);
+                int numColumns = numFlashColumns;
+                int numRows = numFlashRows;
 
-                int[,] rcMatrix = new int[numColumns, numRows];
+                int[,] rcMatrix = new int[numRows,numColumns];
 
                 // Assign object indices to places in the virtual row/column matrix
                 //if (rcMethod.ToString() == "Ordered")
@@ -304,9 +304,9 @@ namespace BCIEssentials.ControllerBehaviors
                 if (rowColumn)
                 {
                     int count = 0;
-                    for (int i = 0; i < numColumns; i++)
+                    for (int i = 0; i < numRows; i++)
                     {
-                        for (int j = 0; j < numRows; j++)
+                        for (int j = 0; j < numColumns; j++)
                         {
                             if (count <= numSelections)
                                 rcMatrix[i, j] = count;
@@ -429,7 +429,7 @@ namespace BCIEssentials.ControllerBehaviors
                 if (checkerboard)
                 {
                     // get the size of the black/white matrices
-                    double maxBWsize = Math.Ceiling(((float)checkerBoardRows * (float)checkerBoardCols) / 2f);
+                    double maxBWsize = Math.Ceiling(((float)numFlashRows * (float)numFlashColumns) / 2f);
 
                     // get the number of rows and columns
                     int bwCols = (int)Math.Ceiling(Math.Sqrt(maxBWsize));
@@ -459,7 +459,7 @@ namespace BCIEssentials.ControllerBehaviors
                     {
 
                         // if there is an odd number of columns
-                        if (checkerBoardCols % 2 == 1)
+                        if (numFlashColumns % 2 == 1)
                         {
                             //evens assigned to black
                             if (shuffledArray[i] % 2 == 0)
@@ -476,10 +476,10 @@ namespace BCIEssentials.ControllerBehaviors
                         }
 
                         // if there is an even number of columns
-                        if (checkerBoardCols % 2 == 0)
+                        if (numFlashColumns % 2 == 0)
                         {
                             //assigned to black
-                            int numR = shuffledArray[i] / checkerBoardCols;
+                            int numR = shuffledArray[i] / numFlashColumns;
                             // print("to place" + shuffledArray[i].ToString());
                             // print("row number" + numR.ToString());
 

--- a/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Behaviors/P300ControllerBehavior.cs
+++ b/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Behaviors/P300ControllerBehavior.cs
@@ -37,10 +37,10 @@ namespace BCIEssentials.ControllerBehaviors
         public bool checkerboard = true;
 
         [Header("Row/Column & Checkerboard Properties")]
-        [Tooltip("Number of columns in the multi-flash RowColumn or Checkerboard")]
-        public int numFlashColumns = 6;
         [Tooltip("Number of rows in multi-flash RowColumn or Checkerboard")]
         public int numFlashRows = 5;
+        [Tooltip("Number of columns in the multi-flash RowColumn or Checkerboard")]
+        public int numFlashColumns = 6;
 
 
         public enum multiFlashMethod

--- a/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Behaviors/P300ControllerBehavior.cs
+++ b/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Behaviors/P300ControllerBehavior.cs
@@ -22,8 +22,8 @@ namespace BCIEssentials.ControllerBehaviors
         public Random randNumFlashes = new Random();
         private int numFlashesPerObjectPerSelection = 3;
 
-        public float onTime = 0.2f;
-        public float offTime = 0.3f;
+        public float onTime = 0.1f;
+        public float offTime = 0.075f;
 
         [Header("Stimulus Flash Paradigm")]
         [Tooltip("If true, only one SPO will flash at a time")]

--- a/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Behaviors/SwitchController.cs
+++ b/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Behaviors/SwitchController.cs
@@ -41,7 +41,7 @@ namespace BCIEssentials.ControllerBehaviors
             int numOptions = _selectableSPOs.Count;
 
             // Create a random non repeating array 
-            int[] trainArray = ArrayUtilities.GenerateRNRA(numTrainingSelections, 0, numOptions);
+            int[] trainArray = ArrayUtilities.GenerateRNRA_FisherYates(numTrainingSelections, 0, numOptions-1);
             LogArrayValues(trainArray);
 
             yield return 0;

--- a/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Controllers/Controller.cs
+++ b/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Controllers/Controller.cs
@@ -470,7 +470,7 @@ public class Controller : MonoBehaviour
     // 
     public int[] MakeRNRA(int arrayLength, int maxRangeValue)
     {
-        return ArrayUtilities.GenerateRNRA_FisherYates(arrayLength, 0, maxRangeValue-1);
+        return ArrayUtilities.GenerateRNRA_FisherYates(arrayLength, 0, maxRangeValue);
     }
 
     public void PrintArray(int[] array)

--- a/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Controllers/Controller.cs
+++ b/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Controllers/Controller.cs
@@ -470,7 +470,7 @@ public class Controller : MonoBehaviour
     // 
     public int[] MakeRNRA(int arrayLength, int maxRangeValue)
     {
-        return ArrayUtilities.GenerateRNRA(arrayLength, 0, maxRangeValue);
+        return ArrayUtilities.GenerateRNRA_FisherYates(arrayLength, 0, maxRangeValue-1);
     }
 
     public void PrintArray(int[] array)

--- a/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Utilities/ArrayUtilities.cs
+++ b/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Utilities/ArrayUtilities.cs
@@ -85,9 +85,9 @@ namespace BCIEssentials.Utilities
         }
         #endregion
 
-        #region RNRA for Flashing Targets
+        #region RNRA for Low Number of Targets and flashing
         /// <summary>
-        /// This is an array to generate randomly flashing targets during the stimulus run.
+        /// This is an array to generate randomly flashing targets during the stimulus run for low number of targets.
         /// This is NOT to be used for training targets. It will take the whole list and shuffle
         /// only guaranteeing that the values will not repeat. It won't guarantee that all values
         /// are presented first before repeating.
@@ -183,6 +183,12 @@ namespace BCIEssentials.Utilities
             if (arrayLength <= 0)
             {
                 return Array.Empty<int>();
+            }
+
+             // Handle the special case where minRangeValue and maxRangeValue are the same
+            if (minRangeValue == maxRangeValue)
+            {
+                return Enumerable.Repeat(minRangeValue, arrayLength).ToArray();
             }
             
             //Generate new Random value

--- a/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Utilities/ArrayUtilities.cs
+++ b/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Utilities/ArrayUtilities.cs
@@ -101,62 +101,62 @@ namespace BCIEssentials.Utilities
         /// <param name="minRangeValue">The lowest value possible to include.</param>
         /// <param name="maxRangeValue">The largest value possible to include.</param>
         /// <returns>An int array</returns>
-        public static int[] GenerateWeightedArray(int arrayLength, int minRangeValue, int maxRangeValue)
-        {
-            if (maxRangeValue < minRangeValue)
-            {
-                throw new ArgumentException("MaxRangeValue must be greater than the MinRangeValue");
-            }
+        // public static int[] GenerateWeightedArray(int arrayLength, int minRangeValue, int maxRangeValue)
+        // {
+        //     if (maxRangeValue < minRangeValue)
+        //     {
+        //         throw new ArgumentException("MaxRangeValue must be greater than the MinRangeValue");
+        //     }
             
-            if (arrayLength <= 0)
-            {
-                return Array.Empty<int>();
-            }
+        //     if (arrayLength <= 0)
+        //     {
+        //         return Array.Empty<int>();
+        //     }
 
-            var range = new List<int>();
-            for (int i = minRangeValue; i <= maxRangeValue; i++) range.Add(i);
+        //     var range = new List<int>();
+        //     for (int i = minRangeValue; i <= maxRangeValue; i++) range.Add(i);
 
-            // Track each value's frequency
-            var frequency = new Dictionary<int, int>();
-            foreach (var value in range) frequency[value] = 0;
+        //     // Track each value's frequency
+        //     var frequency = new Dictionary<int, int>();
+        //     foreach (var value in range) frequency[value] = 0;
 
-            // Min-heap to prioritize least-picked values
-            var minHeap = new SortedSet<(int frequency, int value)>();
-            foreach (var value in range)
-                minHeap.Add((0, value));
+        //     // Min-heap to prioritize least-picked values
+        //     var minHeap = new SortedSet<(int frequency, int value)>();
+        //     foreach (var value in range)
+        //         minHeap.Add((0, value));
 
-            var result = new int[arrayLength];
-            int lastPicked = -1;
-            var random = new Random();
+        //     var result = new int[arrayLength];
+        //     int lastPicked = -1;
+        //     var random = new Random();
 
-            for (int i = 0; i < arrayLength; i++)
-            {
-                // Select the least-picked values, avoiding the last picked
-                var selectedCandidates = new List<(int frequency, int value)>();
+        //     for (int i = 0; i < arrayLength; i++)
+        //     {
+        //         // Select the least-picked values, avoiding the last picked
+        //         var selectedCandidates = new List<(int frequency, int value)>();
 
-                foreach (var entry in minHeap)
-                {
-                    if (entry.value != lastPicked)
-                    {
-                        selectedCandidates.Add(entry);
-                    }
-                }
+        //         foreach (var entry in minHeap)
+        //         {
+        //             if (entry.value != lastPicked)
+        //             {
+        //                 selectedCandidates.Add(entry);
+        //             }
+        //         }
 
-                // Pick randomly among least-picked candidates
-                var choice = selectedCandidates[random.Next(selectedCandidates.Count)];
+        //         // Pick randomly among least-picked candidates
+        //         var choice = selectedCandidates[random.Next(selectedCandidates.Count)];
                 
-                // Update frequency in the dictionary and heap
-                minHeap.Remove(choice);
-                frequency[choice.value]++;
-                minHeap.Add((frequency[choice.value], choice.value));
+        //         // Update frequency in the dictionary and heap
+        //         minHeap.Remove(choice);
+        //         frequency[choice.value]++;
+        //         minHeap.Add((frequency[choice.value], choice.value));
 
-                // Add choice to result and update last picked
-                result[i] = choice.value;
-                lastPicked = choice.value;
-            }
+        //         // Add choice to result and update last picked
+        //         result[i] = choice.value;
+        //         lastPicked = choice.value;
+        //     }
 
-            return result;
-        }
+        //     return result;
+        // }
 
 
         #endregion

--- a/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Utilities/ArrayUtilities.cs
+++ b/Packages/com.bci4kids.bciessentials/Runtime/Scripts/Utilities/ArrayUtilities.cs
@@ -6,9 +6,11 @@ namespace BCIEssentials.Utilities
 {
     public static class ArrayUtilities
     {
+        #region Random Non-Repeating Array (RNRA) for Target Selection
         /// <summary>
         /// Generates an array with the given length populated randomly
         /// with values including and between of the range values.
+        /// This is intended for use in setting up the training targets.
         /// </summary>
         /// <param name="arrayLength">Number of values to include in the range.</param>
         /// <param name="maxRangeValue">The largest value possible to include.</param>
@@ -48,7 +50,7 @@ namespace BCIEssentials.Utilities
                 }
 
                 var (drawIndex, draw) = DrawValue();
-                while (draw == lastDraw && redrawCount < 10)
+                while (draw == lastDraw && redrawCount < 100)
                 {
                     ++redrawCount; //Lets not get stuck in a loop
                     (drawIndex, draw) = DrawValue();
@@ -81,10 +83,88 @@ namespace BCIEssentials.Utilities
             
             return randomizedOptions;
         }
+        #endregion
 
+        #region RNRA for Flashing Targets
+        /// <summary>
+        /// This is an array to generate randomly flashing targets during the stimulus run.
+        /// This is NOT to be used for training targets. It will take the whole list and shuffle
+        /// only guaranteeing that the values will not repeat. It won't guarantee that all values
+        /// are presented first before repeating.
+        /// </summary>
+        /// 
+        /// <summary>
+        /// Generates an array with the given length populated using a MinHeap
+        /// to ensure weighted random selection and optimization.
+        /// </summary>
+        /// <param name="arrayLength">Number of values to include in the range.</param>
+        /// <param name="minRangeValue">The lowest value possible to include.</param>
+        /// <param name="maxRangeValue">The largest value possible to include.</param>
+        /// <returns>An int array</returns>
+        public static int[] GenerateWeightedArray(int arrayLength, int minRangeValue, int maxRangeValue)
+        {
+            if (maxRangeValue < minRangeValue)
+            {
+                throw new ArgumentException("MaxRangeValue must be greater than the MinRangeValue");
+            }
+            
+            if (arrayLength <= 0)
+            {
+                return Array.Empty<int>();
+            }
+
+            var range = new List<int>();
+            for (int i = minRangeValue; i <= maxRangeValue; i++) range.Add(i);
+
+            // Track each value's frequency
+            var frequency = new Dictionary<int, int>();
+            foreach (var value in range) frequency[value] = 0;
+
+            // Min-heap to prioritize least-picked values
+            var minHeap = new SortedSet<(int frequency, int value)>();
+            foreach (var value in range)
+                minHeap.Add((0, value));
+
+            var result = new int[arrayLength];
+            int lastPicked = -1;
+            var random = new Random();
+
+            for (int i = 0; i < arrayLength; i++)
+            {
+                // Select the least-picked values, avoiding the last picked
+                var selectedCandidates = new List<(int frequency, int value)>();
+
+                foreach (var entry in minHeap)
+                {
+                    if (entry.value != lastPicked)
+                    {
+                        selectedCandidates.Add(entry);
+                    }
+                }
+
+                // Pick randomly among least-picked candidates
+                var choice = selectedCandidates[random.Next(selectedCandidates.Count)];
+                
+                // Update frequency in the dictionary and heap
+                minHeap.Remove(choice);
+                frequency[choice.value]++;
+                minHeap.Add((frequency[choice.value], choice.value));
+
+                // Add choice to result and update last picked
+                result[i] = choice.value;
+                lastPicked = choice.value;
+            }
+
+            return result;
+        }
+
+
+        #endregion
+
+        #region FisherYates RNRA
         /// <summary>
         /// Generates an array with the given length populated randomly
-        /// with values including and between of the range values usting
+        /// with values including and between the range values using
         /// the FisherYates shuffle algorithm.
         /// </summary>
         /// <param name="arrayLength">Number of values to include in the range.</param>
@@ -119,13 +199,32 @@ namespace BCIEssentials.Utilities
             //Get the modulo to tell us how long our second array out to be which will be added to the end of the full set of loops.
             int modVal = arrayLength % diffVal;
 
-            for(int i=0; i < disVal; i++)
+            // for(int i=0; i < disVal; i++)
+            // {
+            //     var temp = ShuffleYates(diffVal,minRangeValue,maxRangeValue,random);
+            //     myOptions.AddRange(temp);
+            // }
+            int[] previousArray = null;
+
+            for (int i = 0; i < disVal; i++)
             {
-                var temp = ShuffleYates(diffVal,minRangeValue,maxRangeValue,random);
+                var temp = ShuffleYates(diffVal, minRangeValue, maxRangeValue, random);
+
+                // Ensure no consecutive repeats between arrays
+                if (previousArray != null && previousArray[previousArray.Length - 1] == temp[0])
+                {
+                    // Swap the first element of temp with another element
+                    int swapIndex = random.Next(1, temp.Length);
+                    int tempValue = temp[0];
+                    temp[0] = temp[swapIndex];
+                    temp[swapIndex] = tempValue;
+                }
+
                 myOptions.AddRange(temp);
+                previousArray = temp;
             }
 
-            //bould out the remainder array
+            //build out the remainder array
             int[] tempArray = ShuffleYates(diffVal,minRangeValue,maxRangeValue,random);
             for(int i=0; i < modVal; i++)
             {
@@ -175,5 +274,6 @@ namespace BCIEssentials.Utilities
 
             return shuffledArray;
         }
+        #endregion
     }
 }

--- a/Packages/com.bci4kids.bciessentials/Tests/Editor/ArrayUtilitiesTests.cs
+++ b/Packages/com.bci4kids.bciessentials/Tests/Editor/ArrayUtilitiesTests.cs
@@ -103,7 +103,25 @@ namespace BCIEssentials.Tests.Editor
             CollectionAssert.AreEquivalent(expected, result);
         }
 
-        //Starting tests for the Shuffle and GenerateRNRA_FisherYates versions.
+        [Test]
+        public void GenerateRNRA_LastValueInArray_IsNotLastValueInShuffledArray()
+        {
+            int[] expected = new int[] { 0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 4 };
+
+            var result = ArrayUtilities.GenerateRNRA(expected.Length, 0, 4);
+
+            Assert.AreNotEqual(4, result[^1]);
+            // int minRangeValue = 0;
+            // int maxRangeValue = 4;
+            // int arrayLength = 12;
+
+            // var result = ArrayUtilities.GenerateRNRA(arrayLength, minRangeValue, maxRangeValue);
+
+            // Assert.AreNotEqual(maxRangeValue, result[^1], "The last value in the shuffled array should not be the same as the last value in the original range.");
+        }
+
+        #region ShuffleYates Tests
+        // //Starting tests for the Shuffle and GenerateRNRA_FisherYates versions.
 
         [Test]
         public void GenerateRNRA_FisherYates_InvalidRange_ThrowsArgumentException()
@@ -235,7 +253,7 @@ namespace BCIEssentials.Tests.Editor
 
         }
 
-
+        #endregion
 
     }
 }

--- a/Packages/com.bci4kids.bciessentials/Tests/Editor/ArrayUtilitiesTests.cs
+++ b/Packages/com.bci4kids.bciessentials/Tests/Editor/ArrayUtilitiesTests.cs
@@ -150,6 +150,16 @@ namespace BCIEssentials.Tests.Editor
         }
 
         [Test]
+        public void GenerateRNRA_FisherYates_WhenMaxEqualToMin_ThenReturnsSingleElementArray()
+        {
+            var result = ArrayUtilities.GenerateRNRA_FisherYates(3, 2, 2);
+            int[] expected = Enumerable.Repeat(2, 3).ToArray();
+
+            CollectionAssert.AreEqual(expected, result);
+
+        }
+
+        [Test]
         public void GenerateRNRA_FisherYates_WhenArrayLengthIsLessThanMinMaxDiff_ThenExpectedLength()
         {
             //Variables

--- a/Packages/com.bci4kids.bciessentials/Tests/Runtime/BCIControllerBehaviorTests.cs
+++ b/Packages/com.bci4kids.bciessentials/Tests/Runtime/BCIControllerBehaviorTests.cs
@@ -456,6 +456,7 @@ namespace BCIEssentials.Tests
     {
         private BCIController _testController;
         private BCIControllerBehavior _behavior;
+        private List<SPO> _spos;
 
         [UnitySetUp]
         public override IEnumerator TestSetup()
@@ -466,9 +467,23 @@ namespace BCIEssentials.Tests
             _testController.Initialize();
             
             _behavior = AddComponent<EmptyBCIControllerBehavior>();
+            
+            _spos = new List<SPO>
+            {
+                AddSPOToScene(),
+                AddSPOToScene(),
+                AddSPOToScene(),
+            };
+
+            _behavior.AssignInspectorProperties(new BCIControllerBehaviorExtensions.Properties
+            {
+                _selectableSPOs = _spos
+            });
+
             yield return null;
             
             BCIController.ChangeBehavior(_behavior.BehaviorType);
+
         }
 
         [Test]

--- a/Packages/com.bci4kids.bciessentials/package.json
+++ b/Packages/com.bci4kids.bciessentials/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.bci4kids.bciessentials",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "displayName": "BCI Essentials",
   "description": "A Unity base environment for streamlined development of BCI applications",
   "unity": "2021.3",
@@ -10,7 +10,7 @@
   "license": "MIT",
   "author": {
     "name": "BCI Games",
-    "email": "contact@bci.games\n",
+    "email": "contact@bci.games",
     "url": "https://bci.games/"
   },
   "dependencies": {

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -9,6 +9,7 @@
     "com.unity.test-framework": "1.3.2",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.6.4",
+    "com.unity.toolchain.win-x86_64-linux-x86_64": "2.0.9",
     "com.unity.ugui": "1.0.0",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -86,9 +86,9 @@
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.modules.unitywebrequest": "1.0.0",
+        "com.unity.modules.androidjni": "1.0.0",
         "com.unity.nuget.newtonsoft-json": "3.0.2",
-        "com.unity.modules.androidjni": "1.0.0"
+        "com.unity.modules.unitywebrequest": "1.0.0"
       },
       "url": "https://packages.unity.com"
     },
@@ -100,6 +100,22 @@
         "com.unity.render-pipelines.core": "12.1.8",
         "com.unity.searcher": "4.9.1"
       }
+    },
+    "com.unity.sysroot": {
+      "version": "2.0.10",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.sysroot.linux-x86_64": {
+      "version": "2.0.9",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.sysroot": "2.0.10"
+      },
+      "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
       "version": "1.3.2",
@@ -126,10 +142,20 @@
       "depth": 0,
       "source": "registry",
       "dependencies": {
+        "com.unity.modules.audio": "1.0.0",
         "com.unity.modules.director": "1.0.0",
         "com.unity.modules.animation": "1.0.0",
-        "com.unity.modules.audio": "1.0.0",
         "com.unity.modules.particlesystem": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.toolchain.win-x86_64-linux-x86_64": {
+      "version": "2.0.9",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.sysroot": "2.0.10",
+        "com.unity.sysroot.linux-x86_64": "2.0.9"
       },
       "url": "https://packages.unity.com"
     },


### PR DESCRIPTION
This code has gone through and looked to validate the Fisher-Yates style shuffling for Random Non-Repeating Arrays. It's based on how the old RNRA was done, but been updated to be slightly more efficient similar to the revised RNRA function. 

I have also added additional test for the testing suite to verify this.

Finally, have updated the BCI Behavior scripts with Headers and Tooltips to more clearly show what is happening for new users.

Future step will go back and clean up old scripts no longer required (previous RNRA).