### PR TITLE
336-coroutine-wait

### DIFF
--- a/Runtime/Scripts/Behaviors/BCIControllerBehavior.cs
+++ b/Runtime/Scripts/Behaviors/BCIControllerBehavior.cs
@@ -641,6 +641,14 @@ namespace BCIEssentials.ControllerBehaviors
             reference = StartCoroutine(routine);
         }
 
+        protected IEnumerator WaitForStimulusToComplete()
+        {
+            while (StimulusRunning)
+            {
+                yield return null;
+            }
+        }
+
         //This is a different Stop start Coroutine Method, that is used to return a coroutine reference. Might be better to use this one, but needs testing.
         protected Coroutine Stop_Coroutines_Then_Start_New_Coroutine(ref Coroutine reference_coroutine, IEnumerator routine)
         {

--- a/Runtime/Scripts/Behaviors/P300ControllerBehavior.cs
+++ b/Runtime/Scripts/Behaviors/P300ControllerBehavior.cs
@@ -134,14 +134,10 @@ namespace BCIEssentials.ControllerBehaviors
 
                 yield return new WaitForSecondsRealtime(0.5f);
 
-                // Calculate the length of the trial
-                float trialTime = CalculateTrialTime();
-                Debug.Log("This trial will take ~" + trialTime.ToString() + " seconds");
-
+                // Start stimulus and wait for it to complete
                 StartStimulusRun(false);
-                yield return new WaitForSecondsRealtime(trialTime);
+                yield return StartCoroutine(WaitForStimulusToComplete());
                 yield return new WaitForSecondsRealtime(trainBufferTime);
-                //stimulusOff();
 
                 // If sham feedback is true, then show it
                 if (shamFeedback)
@@ -195,15 +191,10 @@ namespace BCIEssentials.ControllerBehaviors
 
             yield return new WaitForSecondsRealtime(0.5f);
 
-            // Calculate the length of the trial
-            float trialTime = CalculateTrialTime();
-            Debug.Log("This trial will take ~" + trialTime.ToString() + " seconds");
-
+            // Start stimulus and wait for the trial to end
             StartStimulusRun(false);
-
-            yield return new WaitForSecondsRealtime(trialTime);
+            yield return StartCoroutine(WaitForStimulusToComplete());
             yield return new WaitForSecondsRealtime(trainBufferTime);
-            //stimulusOff();
 
             // If sham feedback is true, then show it
             if (shamFeedback)
@@ -923,10 +914,6 @@ namespace BCIEssentials.ControllerBehaviors
             }
 
         }
-
-        
-        
-        
         
         private int[,] Initialize2DMultiFlash()
         {
@@ -940,62 +927,6 @@ namespace BCIEssentials.ControllerBehaviors
 
                 int[,] rcMatrix = new int[numRows, numColumns];
                 return rcMatrix;
-        }
-
-        private float CalculateTrialTime()
-        {
-            // Base time per flash cycle (on + off time)
-            float flashCycle = onTime + offTime;
-            float trialTime = 0f;
-            
-            if (multiFlash)
-            {
-                if (contextAwareMultiFlash)
-                {
-                    // For context-aware multi-flash:
-                    // Number of flash sequences = numFlashesPerObjectPerSelection
-                    // Each sequence includes rows and columns for two subsets
-                    int estimatedSubsetSize = _selectableSPOs.Count / 2;
-                    int estimatedRows = (int)Mathf.Floor(Mathf.Sqrt(estimatedSubsetSize));
-                    int estimatedCols = (int)Mathf.Ceil((float)estimatedSubsetSize / (float)estimatedRows);
-                    
-                    // Total flashes = numFlashes * (rows + columns) * 2 subsets
-                    trialTime = flashCycle * numFlashesPerObjectPerSelection * (estimatedRows + estimatedCols) * 2;
-                }
-                else if (rowColumn)
-                {
-                    // For row-column flashing:
-                    int numColumns = numFlashColumns; 
-                    int numRows = numFlashRows;
-                    
-                    // Total flashes = numFlashes * (rows + columns)
-                    trialTime =  flashCycle * numFlashesPerObjectPerSelection * (numRows + numColumns);
-                }
-                else if (checkerboard)
-                {
-                    // For checkerboard:
-                    // More complex with black/white patterns
-                    int numColumns = numFlashColumns;
-                    int numRows = numFlashRows;
-                    float maxBWsize = Mathf.Ceil(numRows * numColumns / 2f);
-                    
-                    int bwCols = Mathf.CeilToInt(Mathf.Sqrt(maxBWsize));
-                    int bwRows = Mathf.CeilToInt(Mathf.Sqrt(maxBWsize));
-                    
-                    // Adjust rows if needed (same as in CheckerboardFlashRoutine)
-                    if (maxBWsize < ((bwRows * bwCols) - bwRows)) { bwRows--; }
-                                        
-                    // Each flash iteration has 4 components: black rows, white rows, black columns, white columns
-                    trialTime = flashCycle * numFlashesPerObjectPerSelection * (bwRows * 2 + bwCols * 2);
-                }
-            }
-            else
-            {
-                // Default to individual flashes 
-                trialTime = flashCycle * numFlashesPerObjectPerSelection * _selectableSPOs.Count;
-            }
-            
-            return trialTime;
         }
 
         /// <summary>


### PR DESCRIPTION
# Description
Previously, while doing training we were computing the time it would take for the single trial elements to flash, and wait such time before starting the next trial. This would create very long wait times when doing multiflashing since the computed wait time was assuming single flashing of elements.

I implemented a coroutine to determine if the current stimulus is running, to just wait until is done. Thus, no need for wait time calculations.

# Testing
Go to the main branch:
1. Set the P300 controller to multiflash, context-aware flashing.
1. Set a scene with low n_elements on screen to flash, start training (i.e., `T` on the keyboard), and notice the short inter-trial time
2. Increase the number of elements (above 50), start training, and notice the long inter-trial time.

Go to the `336-coroutine-wait branch and repeat the previously mentioned steps.

# Notes
I tested this with single flash, single flash context aware, multiflash context aware. Multiflash row/col and checkerboard seem to break in my branch and main. I will report the separate issue.