### PR TITLE
Indicate training target objects

### DIFF
--- a/Runtime/Scripts/StimulusObjects/SPO.cs
+++ b/Runtime/Scripts/StimulusObjects/SPO.cs
@@ -121,5 +121,17 @@ namespace BCIEssentials.StimulusObjects
             transform.localScale = new Vector3(objectScale.x / scaleValue, objectScale.y / scaleValue,
                     objectScale.z / scaleValue);
         }
+
+        public virtual void DefaultColorEffectOn()
+        {
+            Renderer renderer = GetComponent<Renderer>();
+            renderer.material.color = Color.yellow;
+        }
+
+        public virtual void DefaultColorEffectOff()
+        {
+            Renderer renderer = GetComponent<Renderer>();
+            renderer.material.color = Color.white;
+        }
     }
 }

--- a/Samples~/Controller Hotswapping Example/Prefabs/BCICube_Flashing.prefab
+++ b/Samples~/Controller Hotswapping Example/Prefabs/BCICube_Flashing.prefab
@@ -111,7 +111,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 58dafbcfd2f661d438f57f8ab612995a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  StartStimulusEvent:
+  Selectable: 1
+  ObjectID: -100
+  SelectablePoolIndex: 0
+  OnStimulusTriggered:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 1898853191072348654}
@@ -127,7 +130,7 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-  StopStimulusEvent:
+  OnStimulusEndTriggered:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 1898853191072348654}
@@ -143,7 +146,7 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-  OnSelectedEvent:
+  OnSelected:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 7639228323464969584}
@@ -171,8 +174,38 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-  Selectable: 1
-  SelectablePoolIndex: 0
+  OnSetAsTrainingTarget:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1898853191072348654}
+        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.ColorFlashEffect,
+          Bci4Kids.BciEssentials
+        m_MethodName: Play
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  OnRemovedAsTrainingTarget:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1898853191072348654}
+        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.ColorFlashEffect,
+          Bci4Kids.BciEssentials
+        m_MethodName: SetOff
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!114 &1898853191072348654
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -187,5 +220,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _renderer: {fileID: 1048484350530938657}
   _flashOnColor: {r: 1, g: 0, b: 0, a: 1}
+  _flashOffColor: {r: 1, g: 1, b: 1, a: 1}
+  _startOn: 0
   _flashDurationSeconds: 0.2
   _flashAmount: 3

--- a/Samples~/Motor Imagery/Prefabs/BCICube_Flashing.prefab
+++ b/Samples~/Motor Imagery/Prefabs/BCICube_Flashing.prefab
@@ -111,7 +111,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 58dafbcfd2f661d438f57f8ab612995a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  StartStimulusEvent:
+  Selectable: 1
+  ObjectID: -100
+  SelectablePoolIndex: 0
+  OnStimulusTriggered:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 1898853191072348654}
@@ -127,7 +130,7 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-  StopStimulusEvent:
+  OnStimulusEndTriggered:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 1898853191072348654}
@@ -143,7 +146,7 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-  OnSelectedEvent:
+  OnSelected:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 7639228323464969584}
@@ -171,8 +174,38 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-  Selectable: 1
-  SelectablePoolIndex: 0
+  OnSetAsTrainingTarget:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1898853191072348654}
+        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.ColorFlashEffect,
+          Bci4Kids.BciEssentials
+        m_MethodName: Play
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  OnRemovedAsTrainingTarget:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1898853191072348654}
+        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.ColorFlashEffect,
+          Bci4Kids.BciEssentials
+        m_MethodName: SetOff
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!114 &1898853191072348654
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -187,5 +220,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _renderer: {fileID: 1048484350530938657}
   _flashOnColor: {r: 1, g: 0, b: 0, a: 1}
+  _flashOffColor: {r: 1, g: 1, b: 1, a: 1}
+  _startOn: 0
   _flashDurationSeconds: 0.2
   _flashAmount: 3

--- a/Samples~/P300/Prefabs/BCICube_Flashing.prefab
+++ b/Samples~/P300/Prefabs/BCICube_Flashing.prefab
@@ -192,7 +192,20 @@ MonoBehaviour:
         m_CallState: 2
   OnRemovedAsTrainingTarget:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 1898853191072348654}
+        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.ColorFlashEffect,
+          Bci4Kids.BciEssentials
+        m_MethodName: SetOff
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!114 &1898853191072348654
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Samples~/P300/Prefabs/BCICube_Flashing.prefab
+++ b/Samples~/P300/Prefabs/BCICube_Flashing.prefab
@@ -111,7 +111,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 58dafbcfd2f661d438f57f8ab612995a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  StartStimulusEvent:
+  Selectable: 1
+  ObjectID: -100
+  SelectablePoolIndex: 0
+  OnStimulusTriggered:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 1898853191072348654}
@@ -127,7 +130,7 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-  StopStimulusEvent:
+  OnStimulusEndTriggered:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 1898853191072348654}
@@ -143,7 +146,7 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-  OnSelectedEvent:
+  OnSelected:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 7639228323464969584}
@@ -171,8 +174,25 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-  Selectable: 1
-  SelectablePoolIndex: 0
+  OnSetAsTrainingTarget:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1898853191072348654}
+        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.ColorFlashEffect,
+          Bci4Kids.BciEssentials
+        m_MethodName: Play
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  OnRemovedAsTrainingTarget:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!114 &1898853191072348654
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -187,5 +207,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _renderer: {fileID: 1048484350530938657}
   _flashOnColor: {r: 1, g: 0, b: 0, a: 1}
+  _flashOffColor: {r: 1, g: 1, b: 1, a: 1}
+  _startOn: 0
   _flashDurationSeconds: 0.2
   _flashAmount: 3

--- a/Samples~/SSVEP/Prefabs/BCICube_Flashing.prefab
+++ b/Samples~/SSVEP/Prefabs/BCICube_Flashing.prefab
@@ -192,7 +192,20 @@ MonoBehaviour:
         m_CallState: 2
   OnRemovedAsTrainingTarget:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 1898853191072348654}
+        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.ColorFlashEffect,
+          Bci4Kids.BciEssentials
+        m_MethodName: SetOff
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!114 &1898853191072348654
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Samples~/SSVEP/Prefabs/BCICube_Flashing.prefab
+++ b/Samples~/SSVEP/Prefabs/BCICube_Flashing.prefab
@@ -111,7 +111,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 58dafbcfd2f661d438f57f8ab612995a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  StartStimulusEvent:
+  Selectable: 1
+  ObjectID: -100
+  SelectablePoolIndex: 0
+  OnStimulusTriggered:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 1898853191072348654}
@@ -127,7 +130,7 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-  StopStimulusEvent:
+  OnStimulusEndTriggered:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 1898853191072348654}
@@ -143,7 +146,7 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-  OnSelectedEvent:
+  OnSelected:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 7639228323464969584}
@@ -171,8 +174,25 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-  Selectable: 1
-  SelectablePoolIndex: 0
+  OnSetAsTrainingTarget:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1898853191072348654}
+        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.ColorFlashEffect,
+          Bci4Kids.BciEssentials
+        m_MethodName: Play
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  OnRemovedAsTrainingTarget:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!114 &1898853191072348654
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -187,5 +207,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _renderer: {fileID: 1048484350530938657}
   _flashOnColor: {r: 1, g: 0, b: 0, a: 1}
+  _flashOffColor: {r: 1, g: 1, b: 1, a: 1}
+  _startOn: 0
   _flashDurationSeconds: 0.2
   _flashAmount: 3


### PR DESCRIPTION
This is for [B4K-340](https://bci4kids.atlassian.net/browse/B4K-340)

### Description
This PR is to visually indicate the target of each training selection before stimulus begins.

### Changes
To indicate the targets, we need to assign a method to call when the `OnSetAsTrainingTarget` and `OnRemovedAsTrainingTarget` events are triggered. This is done by modifying those settings in the `SPO` component of the `BCICube_Flashing` prefabs. There are a couple of options to indicate the targets:

**Flash the target object**: This will flash the target SPO three times before the stimulus starts.
- `OnSetAsTrainingTarget` setting: Set to the `Play()` method from `ColorFlashEffect.cs`.
- `OnRemovedAsTrainingTarget` setting: Set to `ColorFlashEffect.SetOff` - this would also work if no function is assigned.

The above description is how I configured those settings for this PR. To use a different indication effect, the following settings can be used.

**Change the target object's size**: This makes use of methods from the `SPO` script to increase and decrease the scale of the target object before stimulus begins.
- `OnSetAsTrainingTarget` setting: Set to `SPO.DefaultScaleEffectOn`.
- `OnRemovedAsTrainingTarget` setting: Set to `SPO.DefaultScaleEffectOff`.

**Change the target object's color**: I added two methods to the `SPO` script to change the color of the target object before stimulus begins.
- `OnSetAsTrainingTarget` setting: Set to `SPO.DefaultColorEffectOn`.
- `OnRemovedAsTrainingTarget` setting: Set to `SPO.DefaultColorEffectOff`.


### Testing

1. Run the P300 Sample Scene, and press T to start training.
2. For each training selection, one of the objects should flash 3 times before stimulus begins.
3. To test the other options for indicating targets, modify the `BCICube_Flashing` prefab in Assets/Samples/P300/Prefabs according to the descriptions above. Run the scene again, and observe the training target indications.
4. You can repeat the above steps for the SSVEP Sample Scene for the SSVEP `BCICube_Flashing` prefab.