### PR TITLE
Corrected use of "Object Ids"

### DIFF
--- a/Runtime/LSL/LSLMarkerWriter.cs
+++ b/Runtime/LSL/LSLMarkerWriter.cs
@@ -16,6 +16,19 @@ namespace BCIEssentials.LSLFramework
             where T: ICommandMarker, new()
             => PushMarker(new T());
 
+        /// <summary>
+        /// Create and send a formatted event marker for the Motor Imagery paradigm
+        /// </summary>
+        /// <param name="objectCount">
+        /// Number of objects (classes) in the trial
+        /// </param>
+        /// <param name="windowLength">
+        /// Length of the processing Epoch <br/>
+        /// <b>Must remain constant between trials</b>
+        /// </param>
+        /// <param name="trainingTarget">
+        /// Index of object (frequency) targetted for training <i>(0-indexed)</i>
+        /// </param>
         public void PushMIMarker
         (
             int objectCount, float windowLength,
@@ -28,6 +41,20 @@ namespace BCIEssentials.LSLFramework
             )
         );
 
+
+        /// <summary>
+        /// Create and send a formatted event marker for the Switch paradigm
+        /// </summary>
+        /// <param name="objectCount">
+        /// Number of objects (classes) in the trial
+        /// </param>
+        /// <param name="windowLength">
+        /// Length of the processing Epoch <br/>
+        /// <b>Must remain constant between trials</b>
+        /// </param>
+        /// <param name="trainingTarget">
+        /// Index of object (frequency) targetted for training <i>(0-indexed)</i>
+        /// </param>
         public void PushSwitchMarker
         (
             int objectCount, float windowLength,
@@ -40,6 +67,23 @@ namespace BCIEssentials.LSLFramework
             )
         );
 
+
+        /// <summary>
+        /// Create and send a formatted event marker for the SSVEP paradigm
+        /// </summary>
+        /// <param name="objectCount">
+        /// Number of objects (frequencies) in the trial
+        /// </param>
+        /// <param name="windowLength">
+        /// Length of the processing Epoch <br/>
+        /// <b>Must remain constant between trials</b>
+        /// </param>
+        /// <param name="frequencies">
+        /// Collection of flashing frequencies used by stimulus objects
+        /// </param>
+        /// <param name="trainingTarget">
+        /// Index of object (frequency) targetted for training <i>(0-indexed)</i>
+        /// </param>
         public void PushSSVEPMarker
         (
             int objectCount, float windowLength,
@@ -54,6 +98,22 @@ namespace BCIEssentials.LSLFramework
             )
         );
 
+        /// <summary>
+        /// Create and send a formatted event marker for the TVEP paradigm
+        /// </summary>
+        /// <param name="objectCount">
+        /// Number of objects (frequencies) in the trial
+        /// </param>
+        /// <param name="windowLength">
+        /// Length of the processing Epoch <br/>
+        /// <b>Must remain constant between trials</b>
+        /// </param>
+        /// <param name="frequencies">
+        /// Collection of flashing frequencies used by stimulus objects
+        /// </param>
+        /// <param name="trainingTarget">
+        /// Index of object (frequency) targetted for training <i>(0-indexed)</i>
+        /// </param>
         public void PushTVEPMarker
         (
             int objectCount, float windowLength,
@@ -68,6 +128,16 @@ namespace BCIEssentials.LSLFramework
             )
         );
 
+        /// <summary>
+        /// Create and send a formatted single flash event marker for the P300 paradigm
+        /// </summary>
+        /// <param name="objectCount">Number of objects in the trial</param>
+        /// <param name="activeObject">
+        /// Index of object being flashed <i>(0-indexed)</i>
+        /// </param>
+        /// <param name="trainingTarget">
+        /// Index of object being targetted for training <i>(0-indexed)</i>
+        /// </param>
         public void PushSingleFlashP300Marker
         (
             int objectCount, int activeObject,
@@ -81,6 +151,16 @@ namespace BCIEssentials.LSLFramework
             )
         );
 
+        /// <summary>
+        /// Create and send a formatted multi-flash event marker for the P300 paradigm
+        /// </summary>
+        /// <param name="objectCount">Number of objects in the trial</param>
+        /// <param name="activeObjects">
+        /// Collection of object indices being flashed together <i>(0-indexed)</i>
+        /// </param>
+        /// <param name="trainingTarget">
+        /// Index of object targetted for training <i>(0-indexed)</i>
+        /// </param>
         public void PushMultiFlashP300Marker
         (
             int objectCount, IEnumerable<int> activeObjects,

--- a/Runtime/LSL/Models/LSLMarkers.cs
+++ b/Runtime/LSL/Models/LSLMarkers.cs
@@ -31,11 +31,17 @@ namespace BCIEssentials.LSLFramework
 
     public abstract class EventMarker: ILSLMarker
     {
+        /// <summary>
+        /// Number of objects or classes in the trial
+        /// </summary>
         public int ObjectCount;
+        /// <summary>
+        /// Index of object, frequency, or class targetted for selection <i>(0-indexed)</i>
+        /// </summary>
         public int TrainingTarget;
 
         public virtual string MarkerString
-        => $"{ObjectCount},{TrainingTarget}";
+        => $"{ObjectCount},{(TrainingTarget < 0? -1: TrainingTarget + 1)}";
 
         public EventMarker
         (
@@ -52,6 +58,10 @@ namespace BCIEssentials.LSLFramework
 
     public abstract class WindowedEventMarker: EventMarker
     {
+        /// <summary>
+        /// Length of the processing Epoch <br/>
+        /// <b>Must remain constant between trials</b>
+        /// </summary>
         public float WindowLength;
 
         public override string MarkerString
@@ -77,6 +87,16 @@ namespace BCIEssentials.LSLFramework
         public override string MarkerString
         => $"mi,{base.MarkerString}";
 
+        /// <param name="objectCount">
+        /// Number of objects (classes) in the trial
+        /// </param>
+        /// <param name="windowLength">
+        /// Length of the processing Epoch <br/>
+        /// <b>Must remain constant between trials</b>
+        /// </param>
+        /// <param name="trainingTarget">
+        /// Index of class targetted for training <i>(0-indexed)</i>
+        /// </param>
         public MIEventMarker
         (
             int objectCount, float windowLength,
@@ -96,6 +116,16 @@ namespace BCIEssentials.LSLFramework
         public override string MarkerString
         => $"switch,{base.MarkerString}";
 
+        /// <param name="objectCount">
+        /// Number of objects (classes) in the trial
+        /// </param>
+        /// <param name="windowLength">
+        /// Length of the processing Epoch <br/>
+        /// <b>Must remain constant between trials</b>
+        /// </param>
+        /// <param name="trainingTarget">
+        /// Index of class targetted for training <i>(0-indexed)</i>
+        /// </param>
         public SwitchEventMarker
         (
             int objectCount, float windowLength,
@@ -108,6 +138,9 @@ namespace BCIEssentials.LSLFramework
 
     public abstract class VisualEvokedPotentialEventMarker: WindowedEventMarker
     {
+        /// <summary>
+        /// Flashing frequencies used by stimulus objects
+        /// </summary>
         public float[] Frequencies;
 
         public override string MarkerString
@@ -140,6 +173,19 @@ namespace BCIEssentials.LSLFramework
         public override string MarkerString
         => $"ssvep,{base.MarkerString}";
 
+        /// <param name="objectCount">
+        /// Number of objects (frequencies) in the trial
+        /// </param>
+        /// <param name="windowLength">
+        /// Length of the processing Epoch <br/>
+        /// <b>Must remain constant between trials</b>
+        /// </param>
+        /// <param name="frequencies">
+        /// Collection of flashing frequencies used by stimulus objects
+        /// </param>
+        /// <param name="trainingTarget">
+        /// Index of object (frequency) targetted for training <i>(0-indexed)</i>
+        /// </param>
         public SSVEPEventMarker
         (
             int objectCount, float windowLength,
@@ -163,6 +209,19 @@ namespace BCIEssentials.LSLFramework
         public override string MarkerString
         => $"tvep,{base.MarkerString}";
 
+        /// <param name="objectCount">
+        /// Number of objects (frequencies) in the trial
+        /// </param>
+        /// <param name="windowLength">
+        /// Length of the processing Epoch <br/>
+        /// <b>Must remain constant between trials</b>
+        /// </param>
+        /// <param name="frequencies">
+        /// Collection of flashing frequencies used by stimulus objects
+        /// </param>
+        /// <param name="trainingTarget">
+        /// Index of object (frequency) targetted for training <i>(0-indexed)</i>
+        /// </param>
         public TVEPEventMarker
         (
             int objectCount, float windowLength,
@@ -203,8 +262,15 @@ namespace BCIEssentials.LSLFramework
         public int ActiveObject;
 
         public override string MarkerString
-        => $"p300,s,{base.MarkerString},{ActiveObject}";
+        => $"p300,s,{base.MarkerString},{ActiveObject + 1}";
 
+        /// <param name="objectCount">Number of objects in the trial</param>
+        /// <param name="activeObject">
+        /// Index of object being flashed <i>(0-indexed)</i>
+        /// </param>
+        /// <param name="trainingTarget">
+        /// Index of object being targetted for training <i>(0-indexed)</i>
+        /// </param>
         public SingleFlashP300EventMarker
         (
             int objectCount, int activeObject,
@@ -230,9 +296,16 @@ namespace BCIEssentials.LSLFramework
         protected string ActiveObjectString
         => ActiveObjects switch {
             null or {Length: 0} => "",
-            _ => $",{string.Join(',', ActiveObjects)}"
+            _ => $",{string.Join(',', ActiveObjects.Select(x => ++x))}"
         };
 
+        /// <param name="objectCount">Number of objects in the trial</param>
+        /// <param name="activeObjects">
+        /// Collection of object indices being flashed together <i>(0-indexed)</i>
+        /// </param>
+        /// <param name="trainingTarget">
+        /// Index of object targetted for training <i>(0-indexed)</i>
+        /// </param>
         public MultiFlashP300EventMarker
         (
             int objectCount, IEnumerable<int> activeObjects,

--- a/Runtime/LSL/Models/LSLResponses.cs
+++ b/Runtime/LSL/Models/LSLResponses.cs
@@ -145,15 +145,20 @@ namespace BCIEssentials.LSLFramework
     public class LSLPing: SingleChannelLSLResponse {}
 
     /// <summary>
-    /// Prediction/Selection response from bci-essentials python back end
+    /// Prediction/Selection response from bci-essentials python back end.
+    /// <br/><i>(0-indexed)</i>
     /// </summary>
     public class LSLPredictionResponse: SingleChannelLSLResponse
     {
+        /// <summary>
+        /// Index of object or class to select <i>(0-indexed)</i>
+        /// </summary>
         public int Value {get; protected set;}
 
         protected override void ParseBody(string body)
         {
             Value = int.Parse(body);
+            if (Value > 0) Value--;
         }
     }
 }

--- a/Runtime/Scripts/Behaviors/BCIControllerBehavior.cs
+++ b/Runtime/Scripts/Behaviors/BCIControllerBehavior.cs
@@ -108,7 +108,7 @@ namespace BCIEssentials.ControllerBehaviors
         public List<SPO> SelectableSPOs => _selectableSPOs;
         
         /// <summary>
-        /// The 
+        /// Index of selection made during the most recently started run
         /// </summary>
         public int? LastSelectedIndex { get; protected set; }
 

--- a/Runtime/Scripts/Behaviors/BCIControllerBehavior.cs
+++ b/Runtime/Scripts/Behaviors/BCIControllerBehavior.cs
@@ -71,8 +71,6 @@ namespace BCIEssentials.ControllerBehaviors
         [Tooltip("Whether to automatically trigger the setup factory when initialized")]
         public bool FactorySetupRequired;
 
-        private int __uniqueID = 1;
-
 
         [StartFoldoutGroup("Training Properties")]
         [Tooltip("The number of training iterations")]
@@ -132,8 +130,6 @@ namespace BCIEssentials.ControllerBehaviors
         private Coroutine _stimulusCoroutine;
         private Coroutine _selectAfterRunCoroutine;
         private Coroutine _trainingCoroutine;
-
-        protected Dictionary<int, SPO> _objectIDtoSPODict = new();
 
 
         #region Life Cycle Methods
@@ -360,10 +356,6 @@ namespace BCIEssentials.ControllerBehaviors
                     break;
                 case SpoPopulationMethod.Tag:
                     _selectableSPOs = GetSelectableSPOsByTag();
-                    AssignIDsToSelectableSPOs(ref __uniqueID);
-
-                    _objectIDtoSPODict.Clear();
-                    AppendSelectableSPOsToObjectIDDictionary();
                     break;
                 default:
                     Debug.LogWarning($"Populating using {populationMethod} is not implemented");
@@ -386,24 +378,6 @@ namespace BCIEssentials.ControllerBehaviors
             }
             return result;
         }
-
-        protected void AssignIDsToSelectableSPOs(ref int idTracker)
-        {
-            int poolIndex = 0;
-            foreach (SPO spo in _selectableSPOs)
-            {
-                if (spo.ObjectID == -100) spo.ObjectID = idTracker++;
-                spo.SelectablePoolIndex = poolIndex++;
-            }
-        }
-
-        protected void AppendSelectableSPOsToObjectIDDictionary()
-        => _selectableSPOs.ForEach(spo => {
-            if (!_objectIDtoSPODict.ContainsKey(spo.ObjectID))
-            {
-                _objectIDtoSPODict.Add(spo.ObjectID, spo);
-            }
-        });
 
 
         /// <summary>

--- a/Runtime/Scripts/Behaviors/MIControllerBehavior.cs
+++ b/Runtime/Scripts/Behaviors/MIControllerBehavior.cs
@@ -21,6 +21,17 @@ namespace BCIEssentials.ControllerBehaviors
         protected int selectionCounter = 0;
         protected int updateCounter = 0;
 
+
+        public override void MakeSelection(int classIndex, bool stopStimulusRun = false)
+        {
+            base.MakeSelection(classIndex, stopStimulusRun);
+            Debug.LogWarning(
+                "You should override this method in an inherited class " +
+                "as object selection is neither deterministic by index " +
+                "between trials nor relevant to the paradigm."
+            );
+        }
+
         public override void PopulateObjectList(SpoPopulationMethod populationMethod = SpoPopulationMethod.Tag)
         {
             base.PopulateObjectList(populationMethod);

--- a/Runtime/Scripts/Behaviors/MIControllerBehavior.cs
+++ b/Runtime/Scripts/Behaviors/MIControllerBehavior.cs
@@ -59,8 +59,7 @@ namespace BCIEssentials.ControllerBehaviors
                 }
 
                 trainTarget = trainArray[i];
-                int targetID = _selectableSPOs[trainTarget].ObjectID; 
-                Debug.Log($"Running training selection {i} on object with ID {targetID}");
+                Debug.Log($"Running training selection {i} on object with ID {trainTarget}");
 
                 SPO targetObject = _selectableSPOs[trainTarget];
                 yield return RunTrainingRound(
@@ -85,7 +84,8 @@ namespace BCIEssentials.ControllerBehaviors
                 yield break;
             }
 
-            SPO targetObject = _selectableSPOs[0];
+            int trainingIndex = 0;
+            SPO targetObject = _selectableSPOs[trainingIndex];
 
             Debug.Log("Starting single training");
             // For a single, specified SPO, run a single training trial
@@ -96,14 +96,13 @@ namespace BCIEssentials.ControllerBehaviors
                 Debug.Log($"Running single training on option {targetObject.name}");
 
                 // Get the index of the target object
-                int targetID = targetObject.ObjectID;
-                Debug.Log($"Running single training on option {targetID}");
+                Debug.Log($"Running single training on option {trainingIndex}");
 
                 // For each window in the trial
                 for (int j = 0; j < (numTrainWindows); j++)
                 {
                     // Send the marker for the window
-                    MarkerWriter.PushMIMarker(1, windowLength, targetID);
+                    MarkerWriter.PushMIMarker(1, windowLength, trainingIndex);
 
                     yield return new WaitForSecondsRealtime(windowLength);
 
@@ -126,54 +125,6 @@ namespace BCIEssentials.ControllerBehaviors
             yield return null;
         }
 
-        /// <summary>
-        /// Select an object from <see cref="SelectableSPOs"/> based on the SPO ObjectID,
-        /// not the index in the list.
-        /// </summary>
-        /// <param name="objectIndex"></param>
-        /// <param name="stopStimulusRun"></param>
-        public override void SelectSPO(int objectID, bool stopStimulusRun = false)
-        {
-            //If the current training type is not single, then run the base method
-            if (CurrentTrainingType != BCITrainingType.Single)
-            {
-                base.SelectSPO(objectID, stopStimulusRun);
-                return;
-            }
-            
-            // If the current training type is single, then make sure the SPO selection is
-            // based on the object ID
-            var objectCount = _selectableSPOs.Count;
-            if (objectCount == 0)
-            {
-                Debug.LogWarning("No Objects to select");
-                return;
-            }
-
-            if(_selectableSPOs.TrueForAll(spo => spo.ObjectID != objectID))
-            {
-                Debug.LogWarning($"ObjectID {objectID} not found in the list of SPOs");
-                return;       
-            }
-
-            // Select the SPO(s) with the matching ObjectID. Doesn't currently break so has to check all
-            foreach (var spo in _selectableSPOs)
-            {
-                if (spo.ObjectID == objectID)
-                {
-                    spo.Select();
-                    LastSelectedSPO = spo;
-                    Debug.Log($"SPO '{spo.gameObject.name}' selected.");
-                }
-            }
-            //I'm unsure if this is needed, but I'm mimicking how the base method handles this
-            if (stopStimulusRun)
-            {
-                StopStimulusRun();
-            }
-
-        }
-
         public override void UpdateClassifier()
         {
             Debug.Log("Updating the classifier");
@@ -182,10 +133,6 @@ namespace BCIEssentials.ControllerBehaviors
 
         protected override void SendWindowMarker(int trainingIndex = -1)
         {
-            if (trainingIndex >= 0 && trainingIndex < SPOCount)
-            {
-                trainingIndex = _selectableSPOs[trainingIndex].ObjectID;
-            }
             MarkerWriter.PushMIMarker(SPOCount, windowLength, trainingIndex);
         }
     }

--- a/Runtime/Scripts/Controllers/BCIController.cs
+++ b/Runtime/Scripts/Controllers/BCIController.cs
@@ -136,29 +136,34 @@ namespace BCIEssentials.Controllers
         }
 
         /// <summary>
-        /// Select an object from <see cref="ActiveBehavior.SelectableSPOs"/>.
+        /// Select a stimulus object or class as relevant to the active behaviour
         /// </summary>
-        /// <param name="objectIndex">The index value of the object to select.</param>
-        /// <param name="stopStimulusRun">If true will end the current stimulus run.</param>
-        public static void SelectSPO(int objectIndex, bool stopStimulusRun = false)
+        /// <param name="selectionIndex">
+        /// The index value of the object/class to select <i>(0-indexed)</i>
+        /// </param>
+        /// <param name="stopStimulusRun">
+        /// If true will end the current stimulus run
+        /// </param>
+        public static void MakeSelection(int selectionIndex, bool stopStimulusRun = false)
         {
             if (Instance == null)
             throw new NullReferenceException("No BCI Controller Instance set");
 
-            Instance.SelectSPO(objectIndex, stopStimulusRun);
+            Instance.MakeSelection(selectionIndex, stopStimulusRun);
         }
-        
+
         /// <summary>
-        /// Select an object from <see cref="ActiveBehavior.SelectableSPOs"/> if no objects were
-        /// selected during a stimulus run.
+        /// Make a selection at the end of a stimulus if no other was made
         /// </summary>
-        /// <param name="objectIndex"></param>
-        public static void SelectSPOAtEndOfRun(int objectIndex)
+        /// <param name="selectionIndex">
+        /// The index value of the object/class to select <i>(0-indexed)</i>
+        /// </param>
+        public static void MakeSelectionAtEndOfRun(int selectionIndex)
         {
             if (Instance == null)
             throw new NullReferenceException("No BCI Controller Instance set");
 
-            Instance.SelectSPOAtEndOfRun(objectIndex);
+            Instance.MakeSelectionAtEndOfRun(selectionIndex);
         }
 
         /// <summary>

--- a/Runtime/Scripts/Controllers/BCIControllerInstance.cs
+++ b/Runtime/Scripts/Controllers/BCIControllerInstance.cs
@@ -161,29 +161,34 @@ namespace BCIEssentials.Controllers
         }
 
         /// <summary>
-        /// Select an object from <see cref="ActiveBehavior.SelectableSPOs"/>.
+        /// Select a stimulus object or class
         /// </summary>
-        /// <param name="objectIndex">The index value of the object to select.</param>
-        /// <param name="stopStimulusRun">If true will end the current stimulus run.</param>
-        public void SelectSPO(int objectIndex, bool stopStimulusRun = false)
+        /// <param name="selectionIndex">
+        /// The index value of the object/class to select <i>(0-indexed)</i>
+        /// </param>
+        /// <param name="stopStimulusRun">
+        /// If true will end the current stimulus run
+        /// </param>
+        public void MakeSelection(int selectionIndex, bool stopStimulusRun = false)
         {
             if (ActiveBehavior == null)
             throw new NullReferenceException("No Active Behavior set");
 
-            ActiveBehavior.SelectSPO(objectIndex, stopStimulusRun);
+            ActiveBehavior.MakeSelection(selectionIndex, stopStimulusRun);
         }
-        
+
         /// <summary>
-        /// Select an object from <see cref="ActiveBehavior.SelectableSPOs"/> if no objects were
-        /// selected during a stimulus run.
+        /// Make a selection at the end of a stimulus if no other was made
         /// </summary>
-        /// <param name="objectIndex"></param>
-        public void SelectSPOAtEndOfRun(int objectIndex)
+        /// <param name="selectionIndex">
+        /// The index value of the object/class to select <i>(0-indexed)</i>
+        /// </param>
+        public void MakeSelectionAtEndOfRun(int selectionIndex)
         {
             if (ActiveBehavior == null)
             throw new NullReferenceException("No Active Behavior set");
 
-            ActiveBehavior.SelectSPOAtEndOfRun(objectIndex);
+            ActiveBehavior.MakeSelectionAtEndOfRun(selectionIndex);
         }
 
         /// <summary>

--- a/Runtime/Scripts/Controllers/BCIControllerShortcuts.cs
+++ b/Runtime/Scripts/Controllers/BCIControllerShortcuts.cs
@@ -25,7 +25,7 @@ namespace BCIEssentials.Controllers
         [EndFoldoutGroup, Space(6)]
         public KeyBind UpdateClassifierBinding;
 
-        public IndexedKeyBindSet ObjectSelectionBindings;
+        public IndexedKeyBindSet SelectionBindings;
         
         [Space]
         public BCIControllerInstance Target;
@@ -40,7 +40,7 @@ namespace BCIEssentials.Controllers
             StartSingleTrainingBinding = KeyCode.Semicolon;
             UpdateClassifierBinding = KeyCode.Backspace;
 
-            ObjectSelectionBindings = new IndexedKeyBindSet
+            SelectionBindings = new IndexedKeyBindSet
             (
                 (0, KeyCode.Alpha0), (1, KeyCode.Alpha1),
                 (2, KeyCode.Alpha2), (3, KeyCode.Alpha3),
@@ -66,7 +66,7 @@ namespace BCIEssentials.Controllers
                         (StartSingleTrainingBinding, Target.StartSingleTraining),
                         (UpdateClassifierBinding, Target.UpdateClassifier)
                     },
-                    Target.SelectSPOAtEndOfRun
+                    Target.MakeSelectionAtEndOfRun
                 );
             }
             else
@@ -80,20 +80,20 @@ namespace BCIEssentials.Controllers
                         (StartSingleTrainingBinding, BCIController.StartSingleTraining),
                         (UpdateClassifierBinding, BCIController.UpdateClassifier)
                     },
-                    BCIController.SelectSPOAtEndOfRun
+                    BCIController.MakeSelectionAtEndOfRun
                 );
             }
         }
 
         private void ProcessShortcuts(
             (KeyBind, Action)[] shortcuts,
-            Action<int> objectSelectionMethod
+            Action<int> selectionMethod
         )
         {
             foreach ((KeyBind keyBind, Action method) in shortcuts)
                 if (keyBind.WasPressedThisFrame) method();
 
-            ObjectSelectionBindings.Process(objectSelectionMethod);
+            SelectionBindings.Process(selectionMethod);
         }
     }
 

--- a/Runtime/Scripts/StimulusObjects/SPO.cs
+++ b/Runtime/Scripts/StimulusObjects/SPO.cs
@@ -17,20 +17,6 @@ namespace BCIEssentials.StimulusObjects
         /// </summary>
         public bool Selectable = true;
 
-        /// <summary>
-        /// Assigned in editor or by the PopulateObjectIDList method, this 
-        /// is a unique identifier for this SPO. It defaults to -100.
-        /// </summary>
-        [Tooltip("Will be set by controller behaviour if the list of objects is dynamically populated")]
-        public int ObjectID = -100;
-
-        /// <summary>
-        /// Assigned by the SPO Controller, this represents the
-        /// index of this SPO in the controllers pool of selectables. 
-        /// </summary>
-        [HideInInspector]
-        public int SelectablePoolIndex;
-
 
         [Header("Start stimulus presentation")]
         [FormerlySerializedAs("StartStimulusEvent")]

--- a/Samples~/Controller Hotswapping Example/Prefabs/ControllerManager.prefab
+++ b/Samples~/Controller Hotswapping Example/Prefabs/ControllerManager.prefab
@@ -207,7 +207,7 @@ MonoBehaviour:
     BoundKey: 59
   UpdateClassifierBinding:
     BoundKey: 8
-  ObjectSelectionBindings:
+  SelectionBindings:
     Bindings:
     - BoundKey: 48
       Index: 0

--- a/Samples~/Motor Imagery/MITraining.unity
+++ b/Samples~/Motor Imagery/MITraining.unity
@@ -294,7 +294,7 @@ MonoBehaviour:
     BoundKey: 59
   UpdateClassifierBinding:
     BoundKey: 8
-  ObjectSelectionBindings:
+  SelectionBindings:
     Bindings:
     - BoundKey: 48
       Index: 0

--- a/Samples~/P300/P300Training.unity
+++ b/Samples~/P300/P300Training.unity
@@ -220,7 +220,7 @@ MonoBehaviour:
     BoundKey: 59
   UpdateClassifierBinding:
     BoundKey: 8
-  ObjectSelectionBindings:
+  SelectionBindings:
     Bindings:
     - BoundKey: 48
       Index: 0

--- a/Samples~/SSVEP/SVVEPTraining.unity
+++ b/Samples~/SSVEP/SVVEPTraining.unity
@@ -216,7 +216,7 @@ MonoBehaviour:
     BoundKey: 59
   UpdateClassifierBinding:
     BoundKey: 8
-  ObjectSelectionBindings:
+  SelectionBindings:
     Bindings:
     - BoundKey: 48
       Index: 0

--- a/Tests/Editor/LSLResponseParsingTests.cs
+++ b/Tests/Editor/LSLResponseParsingTests.cs
@@ -16,9 +16,9 @@ namespace BCIEssentials.Tests.Editor
         => ParseResponseAndAssertType<LSLPing>(sampleString);
 
         [Test]
-        [TestCase("0", 0)]
-        [TestCase("[2]", 2)]
-        [TestCase(" 1 ", 1)]
+        [TestCase("1", 0)]
+        [TestCase("[3]", 2)]
+        [TestCase(" 2 ", 1)]
         public void BuildResponse_WhenPrediction_ThenReturnsPredictionResponse
         (
             string sampleString, int expectedValue

--- a/Tests/Runtime/BCIControllerBehaviorTests.cs
+++ b/Tests/Runtime/BCIControllerBehaviorTests.cs
@@ -373,46 +373,46 @@ namespace BCIEssentials.Tests
         [TestCase(0)]
         [TestCase(1)]
         [TestCase(2)]
-        public void WhenSelectSPO_ThenSPOSelected(int spoIndex)
+        public void WhenMakeSelection_ThenSelectionMade(int spoIndex)
         {
-            _behavior.SelectSPO(spoIndex);
+            _behavior.MakeSelection(spoIndex);
 
-            Assert.AreEqual(_spos[spoIndex], _behavior.LastSelectedSPO);
+            Assert.AreEqual(spoIndex, _behavior.LastSelectedIndex);
         }
 
         [UnityTest]
-        public IEnumerator WhenSelectSPOAndStopStimulusRun_ThenSPOSelectedAndStimulusRunEnded()
+        public IEnumerator WhenMakeSelectionAndStopStimulusRun_ThenSelectionMadeAndStimulusRunEnded()
         {
             _behavior.StartStimulusRun();
             yield return null;
-            _behavior.SelectSPO(0, true);
+            _behavior.MakeSelection(0, true);
 
             Assert.False(_behavior.StimulusRunning);
         }
 
         [UnityTest]
-        public IEnumerator WhenSelectSPOAtEndOfRun_ThenSPOSelected()
+        public IEnumerator WhenMakeSelectionAtEndOfRun_ThenSelectionMade()
         {
             _behavior.StartStimulusRun();
-            _behavior.SelectSPOAtEndOfRun(0);
+            _behavior.MakeSelectionAtEndOfRun(0);
             yield return null;
             _behavior.StopStimulusRun();
             yield return null;
 
-            Assert.AreEqual(_spos[0], _behavior.LastSelectedSPO);
+            Assert.AreEqual(0, _behavior.LastSelectedIndex);
         }
 
         [UnityTest]
-        public IEnumerator WhenSelectSPOAtEndOfRunAndSpoSelectedDuringRun_ThenSpoSelectedNotSelected()
+        public IEnumerator WhenMakeSelectionAtEndOfRunAndSelectionMadeDuringRun_ThenRunningSelectionHolds()
         {
             _behavior.StartStimulusRun();
             yield return null;
-            _behavior.SelectSPOAtEndOfRun(0);
+            _behavior.MakeSelectionAtEndOfRun(0);
             yield return null;
-            _behavior.SelectSPO(1);
+            _behavior.MakeSelection(1);
             _behavior.StopStimulusRun();
 
-            UnityEngine.Assertions.Assert.AreEqual(_spos[1], _behavior.LastSelectedSPO);
+            UnityEngine.Assertions.Assert.AreEqual(1, _behavior.LastSelectedIndex);
         }
     }
 

--- a/Tests/Runtime/BCIControllerBehaviorTests.cs
+++ b/Tests/Runtime/BCIControllerBehaviorTests.cs
@@ -380,20 +380,6 @@ namespace BCIEssentials.Tests
             Assert.AreEqual(_spos[spoIndex], _behavior.LastSelectedSPO);
         }
 
-        //Setup test to check if the SPO Object ID is correctly unique for objects when PopulateObject method is used
-        [UnityTest]
-        public IEnumerator WhenPopulateObjectList_PopulateUniqueSPOIDs()
-        {
-            //Assert that the SPOs have same ID before Populating Object LIst
-            Assert.AreEqual(_spos[0].ObjectID, _spos[1].ObjectID);
-
-            _behavior.PopulateObjectList();
-            yield return null;
-            //Assert now that the SPO IDs are unique
-            Assert.AreNotEqual(_spos[0].ObjectID, _spos[1].ObjectID);
-
-        }
-
         [UnityTest]
         public IEnumerator WhenSelectSPOAndStopStimulusRun_ThenSPOSelectedAndStimulusRunEnded()
         {

--- a/Tests/Runtime/LSLFramework/LSLMarkerWriterTests.cs
+++ b/Tests/Runtime/LSLFramework/LSLMarkerWriterTests.cs
@@ -23,7 +23,7 @@ namespace BCIEssentials.Tests.LSLFramework
         }
 
         [Test]
-        [TestCase(2, 1.5f, 1, "mi,2,1,1.50")]
+        [TestCase(2, 1.5f, 1, "mi,2,2,1.50")]
         [TestCase(2, 1.5f, -1, "mi,2,-1,1.50")]
         [TestCase(2, 2.5f, 4, "mi,2,-1,2.50")]
         [TestCase(2, 2.5f, -2, "mi,2,-1,2.50")]
@@ -41,7 +41,7 @@ namespace BCIEssentials.Tests.LSLFramework
         }
 
         [Test]
-        [TestCase(2, 1.5f, 1, "switch,2,1,1.50")]
+        [TestCase(2, 1.5f, 1, "switch,2,2,1.50")]
         public void PushSwitchMarker_WhenMarkerPushed_ThenPulledWithCorrectFormat
         (
             int objectCount, float windowLength,
@@ -56,7 +56,7 @@ namespace BCIEssentials.Tests.LSLFramework
         }
 
         [Test]
-        [TestCase(4, 1.5f, new[] {12.5f,18.7f,24.4f,30.1f}, 2, "ssvep,4,2,1.50,12.5,18.7,24.4,30.1")]
+        [TestCase(4, 1.5f, new[] {12.5f,18.7f,24.4f,30.1f}, 2, "ssvep,4,3,1.50,12.5,18.7,24.4,30.1")]
         public void PushSSVEPMarker_WhenMarkerPushed_ThenPulledWithCorrectFormat
         (
             int objectCount, float windowLength, float[] frequencies,
@@ -72,7 +72,7 @@ namespace BCIEssentials.Tests.LSLFramework
         }
 
         [Test]
-        [TestCase(6, 1.5f, new[] {15f}, 2, "tvep,6,2,1.50,15")]
+        [TestCase(6, 1.5f, new[] {15f}, 2, "tvep,6,3,1.50,15")]
         public void PushTVEPMarker_WhenMarkerPushed_ThenPulledWithCorrectFormat
         (
             int objectCount, float windowLength, float[] frequencies,
@@ -88,7 +88,7 @@ namespace BCIEssentials.Tests.LSLFramework
         }
 
         [Test]
-        [TestCase(8, 1, 3, "p300,s,8,3,1")]
+        [TestCase(8, 1, 3, "p300,s,8,4,2")]
         public void PushSingleFlashP300Marker_WhenMarkerPushed_ThenPulledWithCorrectFormat
         (
             int objectCount, int activeObject,
@@ -103,7 +103,7 @@ namespace BCIEssentials.Tests.LSLFramework
         }
 
         [Test]
-        [TestCase(8, new[] {1,3,5,7}, 3, "p300,m,8,3,1,3,5,7")]
+        [TestCase(8, new[] {1,3,5,7}, 3, "p300,m,8,4,2,4,6,8")]
         public void PushMultiFlashP300Marker_WhenMarkerPushed_ThenPulledWithCorrectFormat
         (
             int objectCount, int[] activeObjects,

--- a/Tests/Runtime/LSLFramework/LSLResponseProviderTests.cs
+++ b/Tests/Runtime/LSLFramework/LSLResponseProviderTests.cs
@@ -74,7 +74,7 @@ namespace BCIEssentials.Tests.LSLFramework
 
             yield return new WaitForSecondsRealtime(0.05f);
             Assert.NotNull(prediction);
-            Assert.AreEqual(1, prediction.Value);
+            Assert.AreEqual(0, prediction.Value);
         }
 
         [UnityTest]

--- a/Tests/Runtime/LSLFramework/LSLStreamReaderTests.cs
+++ b/Tests/Runtime/LSLFramework/LSLStreamReaderTests.cs
@@ -89,7 +89,7 @@ namespace BCIEssentials.Tests.LSLFramework
             Assert.AreEqual(1, responses.Length);
             Assert.IsInstanceOf<LSLPredictionResponse>(responses[0]);
             var prediction = responses[0] as LSLPredictionResponse;
-            Assert.AreEqual(1, prediction.Value);
+            Assert.AreEqual(0, prediction.Value);
         }
 
         

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.bci4kids.bciessentials",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "displayName": "BCI Essentials",
   "description": "A Unity base environment for streamlined development of BCI applications",
   "unity": "2021.3",


### PR DESCRIPTION
# Changes
- Updated LSL framework helpers to "translate" between 1-indexed markers for/from python and 0-indexed bindings that are much easier to use
  - Added docstrings to LSL framework classes and methods
- Removed all uses of "Object ID" on the assertion that object identity is only relevant to a single trial
- Added warning to selection method of MI controller behaviour to indicate to any end user that they really shouldn't be using it as is without providing an opinionated alternative behaviour

# To Validate
- Is it clear which of 0 vs 1 indexed values to pass to marker writes and receive from predictions?
  - Is this "translation" more convenient and intuitive than the alternative?
- Is the warning provided by the MI controller sufficient?
  - *my thought is that it doesn't really make sense to use that controller as is without directing input to something entirely unrelated to stimulus objects*
- Run through smoke tests, make sure things still work