### PR TITLE
363-empty-timestamps

### DIFF
--- a/Runtime/Scripts/Behaviors/BCIControllerBehavior.cs
+++ b/Runtime/Scripts/Behaviors/BCIControllerBehavior.cs
@@ -619,7 +619,7 @@ namespace BCIEssentials.ControllerBehaviors
             yield return new WaitForSecondsRealtime(preStimulusBuffer);
             StartStimulusRun();
             yield return stimulusDelayRoutine;
-            StopStimulusRun();
+            StimulusRunning = false;
             yield return new WaitForSecondsRealtime(postStimulusBuffer);
 
             if (shamFeedback && enableShamFeedback)

--- a/Runtime/Scripts/Behaviors/P300ControllerBehavior.cs
+++ b/Runtime/Scripts/Behaviors/P300ControllerBehavior.cs
@@ -107,7 +107,7 @@ namespace BCIEssentials.ControllerBehaviors
                 _ => null
             };
             
-            StopStimulusRun();
+            StimulusRunning = false;
         }
 
         //TODO There is a bug where this is sending "Trial Ended" before the last flash is sent.

--- a/Runtime/Scripts/Behaviors/P300ControllerBehavior.cs
+++ b/Runtime/Scripts/Behaviors/P300ControllerBehavior.cs
@@ -107,7 +107,7 @@ namespace BCIEssentials.ControllerBehaviors
                 _ => null
             };
             
-            StimulusRunning = false;
+            StopStimulusRun();
         }
 
         //TODO There is a bug where this is sending "Trial Ended" before the last flash is sent.


### PR DESCRIPTION
# Description
There was an issue where the P300 training sequence would sent the `Trial Ends` marker twice. This behaviour would break Bessy-Python as shown in the Jira ticket associated to this PR.

The isse was on the fact that `P300ControllerBehavior.RunStimulusRoutine()` and `BCIControllerBehavior.RunTrainingRound` would both call the `StopStimulusRun()` method. Thus, sending the marker twice.

# Implementation
I changed `BCIControllerBehavior.RunTrainingRound` so that it would simply set the `StimulusRunning` flag to false, rather than calling the method.

This solves the issue but IDK if this is the right implementation.

# Testing
Run a training scene and enable the LSL logs, see that the `Trial Ends` is only called once per trial during training (T) or stimulus (S) sequences