### PR TITLE
Clarified Marker Structures

### DIFF
--- a/Runtime/LSL/LSLMarkerWriter.cs
+++ b/Runtime/LSL/LSLMarkerWriter.cs
@@ -16,8 +16,9 @@ namespace BCIEssentials.LSLFramework
             where T: ICommandMarker, new()
             => PushMarker(new T());
 
+
         /// <summary>
-        /// Create and send a formatted event marker for the Motor Imagery paradigm
+        /// Create and send a training marker for the Motor Imagery paradigm
         /// </summary>
         /// <param name="objectCount">
         /// Number of objects (classes) in the trial
@@ -29,50 +30,85 @@ namespace BCIEssentials.LSLFramework
         /// <param name="trainingTarget">
         /// Index of object (frequency) targetted for training <i>(0-indexed)</i>
         /// </param>
-        public void PushMIMarker
+        public void PushMITrainingMarker
         (
-            int objectCount, float epochLength,
-            int trainingTarget = -1
+            int objectCount,
+            int trainingTarget,
+            float epochLength
         )
-        => PushMarker(
-            new MIEventMarker
-            (
-                objectCount, epochLength, trainingTarget
-            )
+        => PushMarker(new MIEventMarker
+            (objectCount, trainingTarget, epochLength)
         );
 
-
         /// <summary>
-        /// Create and send a formatted event marker for the Switch paradigm
+        /// Create and send a classification marker for the Motor Imagery paradigm
+        /// <br/><b>Will trigger a prediction in <see cref="epochLength"/> seconds</b>
         /// </summary>
         /// <param name="objectCount">
         /// Number of objects (classes) in the trial
         /// </param>
         /// <param name="epochLength">
-        /// Length of the processing Epoch <br/>
-        /// <b>Must remain constant between trials</b>
+        /// Arbitrary length of the processing Epoch <br/>
         /// </param>
-        /// <param name="trainingTarget">
-        /// Index of object (frequency) targetted for training <i>(0-indexed)</i>
-        /// </param>
-        public void PushSwitchMarker
+        public void PushMIClassificationMarker
         (
-            int objectCount, float epochLength,
-            int trainingTarget = -1
+            int objectCount, float epochLength
         )
-        => PushMarker(
-            new SwitchEventMarker
-            (
-                objectCount, epochLength, trainingTarget
-            )
+        => PushMarker(new MIEventMarker
+            (objectCount, -1, epochLength)
         );
 
 
         /// <summary>
-        /// Create and send a formatted event marker for the SSVEP paradigm
+        /// Create and send a training marker for the Switch paradigm
+        /// </summary>
+        /// <param name="objectCount">
+        /// Number of objects (classes) in the trial
+        /// </param>
+        /// <param name="trainingTarget">
+        /// Index of object (frequency) targetted for training <i>(0-indexed)</i>
+        /// </param>
+        /// <param name="epochLength">
+        /// Length of the processing Epoch <br/>
+        /// <b>Must remain constant between trials</b>
+        /// </param>
+        public void PushSwitchTrainingMarker
+        (
+            int objectCount,
+            int trainingTarget,
+            float epochLength
+        )
+        => PushMarker(new SwitchEventMarker
+            (objectCount, trainingTarget, epochLength)
+        );
+
+        /// <summary>
+        /// Create and send a classification marker for the Switch paradigm
+        /// <br/><b>Will trigger a prediction in <see cref="epochLength"/> seconds</b>
+        /// </summary>
+        /// <param name="objectCount">
+        /// Number of objects (classes) in the trial
+        /// </param>
+        /// <param name="epochLength">
+        /// Arbitrary length of the processing Epoch <br/>
+        /// </param>
+        public void PushSwitchClassificationMarker
+        (
+            int objectCount, float epochLength
+        )
+        => PushMarker(new SwitchEventMarker
+            (objectCount, -1, epochLength)
+        );
+
+
+        /// <summary>
+        /// Create and send a training marker for the SSVEP paradigm
         /// </summary>
         /// <param name="objectCount">
         /// Number of objects (frequencies) in the trial
+        /// </param>
+        /// <param name="trainingTarget">
+        /// Index of object (frequency) targetted for training <i>(0-indexed)</i>
         /// </param>
         /// <param name="epochLength">
         /// Length of the processing Epoch <br/>
@@ -81,28 +117,47 @@ namespace BCIEssentials.LSLFramework
         /// <param name="frequencies">
         /// Collection of flashing frequencies used by stimulus objects
         /// </param>
-        /// <param name="trainingTarget">
-        /// Index of object (frequency) targetted for training <i>(0-indexed)</i>
-        /// </param>
-        public void PushSSVEPMarker
+        public void PushSSVEPTrainingMarker
         (
-            int objectCount, float epochLength,
-            IEnumerable<float> frequencies,
-            int trainingTarget = -1
+            int objectCount,
+            int trainingTarget,
+            float epochLength,
+            IEnumerable<float> frequencies
         )
-        => PushMarker(
-            new SSVEPEventMarker
-            (
-                objectCount, epochLength,
-                frequencies, trainingTarget
-            )
+        => PushMarker(new SSVEPEventMarker
+            (objectCount, trainingTarget, epochLength, frequencies)
         );
 
         /// <summary>
-        /// Create and send a formatted event marker for the TVEP paradigm
+        /// Create and send a classification marker for the SSVEP paradigm
+        /// <br/><b>Will trigger a prediction in <see cref="epochLength"/> seconds</b>
+        /// </summary>
+        /// <param name="objectCount">
+        /// Number of objects (classes) in the trial
+        /// </param>
+        /// <param name="epochLength">
+        /// Arbitrary length of the processing Epoch <br/>
+        /// </param>
+        /// <param name="frequencies">
+        /// Collection of flashing frequencies used by stimulus objects
+        /// </param>
+        public void PushSSVEPClassificationMarker
+        (
+            int objectCount, float epochLength,
+            IEnumerable<float> frequencies
+        )
+        => PushMarker(new SSVEPEventMarker
+            (objectCount, -1, epochLength, frequencies)
+        );
+
+        /// <summary>
+        /// Create and send a training marker for the TVEP paradigm
         /// </summary>
         /// <param name="objectCount">
         /// Number of objects (frequencies) in the trial
+        /// </param>
+        /// <param name="trainingTarget">
+        /// Index of object (frequency) targetted for training <i>(0-indexed)</i>
         /// </param>
         /// <param name="epochLength">
         /// Length of the processing Epoch <br/>
@@ -111,67 +166,112 @@ namespace BCIEssentials.LSLFramework
         /// <param name="frequencies">
         /// Collection of flashing frequencies used by stimulus objects
         /// </param>
-        /// <param name="trainingTarget">
-        /// Index of object (frequency) targetted for training <i>(0-indexed)</i>
-        /// </param>
-        public void PushTVEPMarker
+        public void PushTVEPTrainingMarker
         (
-            int objectCount, float epochLength,
-            IEnumerable<float> frequencies,
-            int trainingTarget = -1
+            int objectCount,
+            int trainingTarget,
+            float epochLength,
+            IEnumerable<float> frequencies
         )
-        => PushMarker(
-            new TVEPEventMarker
-            (
-                objectCount, epochLength,
-                frequencies, trainingTarget
-            )
+        => PushMarker(new TVEPEventMarker
+            (objectCount, trainingTarget, epochLength, frequencies)
         );
 
         /// <summary>
-        /// Create and send a formatted single flash event marker for the P300 paradigm
+        /// Create and send a classification marker for the TVEP paradigm
+        /// <br/><b>Will trigger a prediction in <see cref="epochLength"/> seconds</b>
+        /// </summary>
+        /// <param name="objectCount">
+        /// Number of objects (classes) in the trial
+        /// </param>
+        /// <param name="epochLength">
+        /// Arbitrary length of the processing Epoch <br/>
+        /// </param>
+        /// <param name="frequencies">
+        /// Collection of flashing frequencies used by stimulus objects
+        /// </param>
+        public void PushTVEPClassificationMarker
+        (
+            int objectCount, float epochLength,
+            IEnumerable<float> frequencies
+        )
+        => PushMarker(new TVEPEventMarker
+            (objectCount, -1, epochLength, frequencies)
+        );
+
+
+        /// <summary>
+        /// Create and send a single flash training marker for the P300 paradigm
+        /// </summary>
+        /// <param name="objectCount">Number of objects in the trial</param>
+        /// <param name="trainingTarget">
+        /// Index of object being targetted for training <i>(0-indexed)</i>
+        /// </param>
+        /// <param name="activeObject">
+        /// Index of object being flashed <i>(0-indexed)</i>
+        /// </param>
+        public void PushSingleFlashP300TrainingMarker
+        (
+            int objectCount,
+            int trainingTarget,
+            int activeObject
+        )
+        => PushMarker(new SingleFlashP300EventMarker
+            (objectCount, trainingTarget, activeObject)
+        );
+
+        /// <summary>
+        /// Create and send a single flash classification marker for the P300 paradigm
+        /// <br/><b>Will trigger a prediction at the end of the trial</b>
         /// </summary>
         /// <param name="objectCount">Number of objects in the trial</param>
         /// <param name="activeObject">
         /// Index of object being flashed <i>(0-indexed)</i>
         /// </param>
-        /// <param name="trainingTarget">
-        /// Index of object being targetted for training <i>(0-indexed)</i>
-        /// </param>
-        public void PushSingleFlashP300Marker
+        public void PushSingleFlashP300ClassificationMarker
         (
-            int objectCount, int activeObject,
-            int trainingTarget = -1
+            int objectCount, int activeObject
         )
-        => PushMarker(
-            new SingleFlashP300EventMarker
-            (
-                objectCount, activeObject,
-                trainingTarget
-            )
+        => PushMarker(new SingleFlashP300EventMarker
+            (objectCount, -1, activeObject)
         );
 
         /// <summary>
-        /// Create and send a formatted multi-flash event marker for the P300 paradigm
+        /// Create and send a multi-flash training marker for the P300 paradigm
+        /// </summary>
+        /// <param name="objectCount">Number of objects in the trial</param>
+        /// <param name="trainingTarget">
+        /// Index of object targetted for training <i>(0-indexed)</i>
+        /// </param>
+        /// <param name="activeObjects">
+        /// Collection of object indices being flashed together <i>(0-indexed)</i>
+        /// </param>
+        public void PushMultiFlashP300TrainingMarker
+        (
+            int objectCount,
+            int trainingTarget,
+            IEnumerable<int> activeObjects
+        )
+        => PushMarker(new MultiFlashP300EventMarker
+            (objectCount, trainingTarget, activeObjects)
+        );
+
+        /// <summary>
+        /// Create and send a multi-flash classification marker for the P300 paradigm
+        /// <br/><b>Will trigger a prediction at the end of the trial</b>
         /// </summary>
         /// <param name="objectCount">Number of objects in the trial</param>
         /// <param name="activeObjects">
         /// Collection of object indices being flashed together <i>(0-indexed)</i>
         /// </param>
-        /// <param name="trainingTarget">
-        /// Index of object targetted for training <i>(0-indexed)</i>
-        /// </param>
-        public void PushMultiFlashP300Marker
+        public void PushMultiFlashP300ClassificationMarker
         (
-            int objectCount, IEnumerable<int> activeObjects,
-            int trainingTarget = -1
+            int objectCount, IEnumerable<int> activeObjects
         )
-        => PushMarker(
-            new MultiFlashP300EventMarker
-            (
-                objectCount, activeObjects, trainingTarget
-            )
+        => PushMarker(new MultiFlashP300EventMarker
+            (objectCount, -1, activeObjects)
         );
+
 
         public void PushMarker(ILSLMarker marker)
             => PushString(marker.MarkerString);

--- a/Runtime/LSL/LSLMarkerWriter.cs
+++ b/Runtime/LSL/LSLMarkerWriter.cs
@@ -42,8 +42,10 @@ namespace BCIEssentials.LSLFramework
 
         /// <summary>
         /// Create and send a classification marker for the Motor Imagery paradigm
-        /// <br/><b>Will trigger a prediction in <see cref="epochLength"/> seconds</b>
         /// </summary>
+        /// <remarks>
+        /// Will trigger a prediction in <paramref name="epochLength"/> seconds
+        /// </remarks>
         /// <param name="objectCount">
         /// Number of objects (classes) in the trial
         /// </param>
@@ -84,8 +86,10 @@ namespace BCIEssentials.LSLFramework
 
         /// <summary>
         /// Create and send a classification marker for the Switch paradigm
-        /// <br/><b>Will trigger a prediction in <see cref="epochLength"/> seconds</b>
         /// </summary>
+        /// <remarks>
+        /// Will trigger a prediction in <paramref name="epochLength"/> seconds
+        /// </remarks>
         /// <param name="objectCount">
         /// Number of objects (classes) in the trial
         /// </param>
@@ -130,10 +134,12 @@ namespace BCIEssentials.LSLFramework
 
         /// <summary>
         /// Create and send a classification marker for the SSVEP paradigm
-        /// <br/><b>Will trigger a prediction in <see cref="epochLength"/> seconds</b>
+        /// </summary>
+        /// <remarks>
+        /// Will trigger a prediction in <paramref name="epochLength"/> seconds
         /// <br/>or at the end of the trial
         /// <br/>depending on python configuration
-        /// </summary>
+        /// </remarks>
         /// <param name="objectCount">
         /// Number of objects (classes) in the trial
         /// </param>
@@ -181,10 +187,12 @@ namespace BCIEssentials.LSLFramework
 
         /// <summary>
         /// Create and send a classification marker for the TVEP paradigm
-        /// <br/><b>Will trigger a prediction in <see cref="epochLength"/> seconds</b>
+        /// </summary>
+        /// <remarks>
+        /// Will trigger a prediction in <paramref name="epochLength"/> seconds
         /// <br/>or at the end of the trial
         /// <br/>depending on python configuration
-        /// </summary>
+        /// </remarks>
         /// <param name="objectCount">
         /// Number of objects (classes) in the trial
         /// </param>
@@ -226,8 +234,10 @@ namespace BCIEssentials.LSLFramework
 
         /// <summary>
         /// Create and send a single flash classification marker for the P300 paradigm
-        /// <br/><b>Will trigger a prediction at the end of the trial</b>
         /// </summary>
+        /// <remarks>
+        /// Will trigger a prediction at the end of the trial
+        /// </remarks>
         /// <param name="objectCount">Number of objects in the trial</param>
         /// <param name="activeObject">
         /// Index of object being flashed <i>(0-indexed)</i>
@@ -262,8 +272,10 @@ namespace BCIEssentials.LSLFramework
 
         /// <summary>
         /// Create and send a multi-flash classification marker for the P300 paradigm
-        /// <br/><b>Will trigger a prediction at the end of the trial</b>
         /// </summary>
+        /// <remarks>
+        /// Will trigger a prediction at the end of the trial
+        /// </remarks>
         /// <param name="objectCount">Number of objects in the trial</param>
         /// <param name="activeObjects">
         /// Collection of object indices being flashed together <i>(0-indexed)</i>

--- a/Runtime/LSL/LSLMarkerWriter.cs
+++ b/Runtime/LSL/LSLMarkerWriter.cs
@@ -131,6 +131,8 @@ namespace BCIEssentials.LSLFramework
         /// <summary>
         /// Create and send a classification marker for the SSVEP paradigm
         /// <br/><b>Will trigger a prediction in <see cref="epochLength"/> seconds</b>
+        /// <br/>or at the end of the trial
+        /// <br/>depending on python configuration
         /// </summary>
         /// <param name="objectCount">
         /// Number of objects (classes) in the trial
@@ -180,6 +182,8 @@ namespace BCIEssentials.LSLFramework
         /// <summary>
         /// Create and send a classification marker for the TVEP paradigm
         /// <br/><b>Will trigger a prediction in <see cref="epochLength"/> seconds</b>
+        /// <br/>or at the end of the trial
+        /// <br/>depending on python configuration
         /// </summary>
         /// <param name="objectCount">
         /// Number of objects (classes) in the trial

--- a/Runtime/LSL/Models/LSLMarkerReceipts.cs
+++ b/Runtime/LSL/Models/LSLMarkerReceipts.cs
@@ -139,7 +139,7 @@ namespace BCIEssentials.LSLFramework
     public class SwitchEventMarkerReceipt: EpochEventMarkerReceipt {}
 
 
-    public abstract class VisualEvokedPotentialEventMarkerReceipt: EpochEventMarkerReceipt
+    public abstract class FrequenciesEventMarkerReceipt: EpochEventMarkerReceipt
     {
         public float[] Frequencies {get; protected set;}
 
@@ -160,14 +160,14 @@ namespace BCIEssentials.LSLFramework
     /// <br/><br/>
     /// "ssvep,{object count},{train target (-1 if n/a)},{epoch length},{...frequencies}"
     /// </summary>
-    public class SSVEPEventMarkerReceipt: VisualEvokedPotentialEventMarkerReceipt {}
+    public class SSVEPEventMarkerReceipt: FrequenciesEventMarkerReceipt {}
     
     /// <summary>
     /// Receipt for TVEP event marker in the format:
     /// <br/><br/>
     /// "tvep,{object count},{train target (-1 if n/a)},{epoch length},{...frequencies}"
     /// </summary>
-    public class TVEPEventMarkerReceipt: VisualEvokedPotentialEventMarkerReceipt {}
+    public class TVEPEventMarkerReceipt: FrequenciesEventMarkerReceipt {}
 
 
     /// <summary>

--- a/Runtime/LSL/Models/LSLMarkers.cs
+++ b/Runtime/LSL/Models/LSLMarkers.cs
@@ -136,7 +136,7 @@ namespace BCIEssentials.LSLFramework
     }
 
 
-    public abstract class VisualEvokedPotentialEventMarker: EpochEventMarker
+    public abstract class FrequenciesEventMarker: EpochEventMarker
     {
         /// <summary>
         /// Flashing frequencies used by stimulus objects
@@ -152,7 +152,7 @@ namespace BCIEssentials.LSLFramework
             _ => $",{string.Join(",", Frequencies)}"
         };
 
-        public VisualEvokedPotentialEventMarker
+        public FrequenciesEventMarker
         (
             int objectCount, int trainingTarget,
             float epochLength,  float[] frequencies
@@ -167,7 +167,7 @@ namespace BCIEssentials.LSLFramework
     /// <br/><br/>
     /// "ssvep,{object count},{train target (-1 if n/a)},{epoch length},{...frequencies}"
     /// </summary>
-    public class SSVEPEventMarker: VisualEvokedPotentialEventMarker
+    public class SSVEPEventMarker: FrequenciesEventMarker
     {
         public override string MarkerString
         => $"ssvep,{base.MarkerString}";
@@ -202,7 +202,7 @@ namespace BCIEssentials.LSLFramework
     /// <br/><br/>
     /// "ssvep,{object count},{train target (-1 if n/a)},{epoch length},{...frequencies}"
     /// </summary>
-    public class TVEPEventMarker: VisualEvokedPotentialEventMarker
+    public class TVEPEventMarker: FrequenciesEventMarker
     {
         public override string MarkerString
         => $"tvep,{base.MarkerString}";

--- a/Runtime/LSL/Models/LSLMarkers.cs
+++ b/Runtime/LSL/Models/LSLMarkers.cs
@@ -69,8 +69,8 @@ namespace BCIEssentials.LSLFramework
 
         public EpochEventMarker
         (
-            int objectCount, float epochLength,
-            int trainingTarget
+            int objectCount, int trainingTarget,
+            float epochLength
         ): base(objectCount, trainingTarget)
         {
             EpochLength = epochLength;
@@ -90,19 +90,19 @@ namespace BCIEssentials.LSLFramework
         /// <param name="objectCount">
         /// Number of objects (classes) in the trial
         /// </param>
+        /// <param name="trainingTarget">
+        /// Index of class targetted for training <i>(0-indexed)</i>
+        /// </param>
         /// <param name="epochLength">
         /// Length of the processing Epoch <br/>
         /// <b>Must remain constant between trials</b>
         /// </param>
-        /// <param name="trainingTarget">
-        /// Index of class targetted for training <i>(0-indexed)</i>
-        /// </param>
         public MIEventMarker
         (
-            int objectCount, float epochLength,
-            int trainingTarget = -1
+            int objectCount, int trainingTarget,
+            float epochLength
         )
-        : base(objectCount, epochLength, trainingTarget)
+        : base(objectCount, trainingTarget, epochLength)
         {}
     }
 
@@ -119,19 +119,19 @@ namespace BCIEssentials.LSLFramework
         /// <param name="objectCount">
         /// Number of objects (classes) in the trial
         /// </param>
+        /// <param name="trainingTarget">
+        /// Index of class targetted for training <i>(0-indexed)</i>
+        /// </param>
         /// <param name="epochLength">
         /// Length of the processing Epoch <br/>
         /// <b>Must remain constant between trials</b>
         /// </param>
-        /// <param name="trainingTarget">
-        /// Index of class targetted for training <i>(0-indexed)</i>
-        /// </param>
         public SwitchEventMarker
         (
-            int objectCount, float epochLength,
-            int trainingTarget = -1
+            int objectCount, int trainingTarget,
+            float epochLength
         )
-        : base(objectCount, epochLength, trainingTarget)
+        : base(objectCount, trainingTarget, epochLength)
         {}
     }
 
@@ -154,10 +154,9 @@ namespace BCIEssentials.LSLFramework
 
         public VisualEvokedPotentialEventMarker
         (
-            int objectCount, float epochLength,
-            float[] frequencies,
-            int trainingTarget = -1
-        ): base(objectCount, epochLength, trainingTarget)
+            int objectCount, int trainingTarget,
+            float epochLength,  float[] frequencies
+        ): base(objectCount, trainingTarget, epochLength)
         {
             Frequencies = frequencies;
         }
@@ -176,6 +175,9 @@ namespace BCIEssentials.LSLFramework
         /// <param name="objectCount">
         /// Number of objects (frequencies) in the trial
         /// </param>
+        /// <param name="trainingTarget">
+        /// Index of object (frequency) targetted for training <i>(0-indexed)</i>
+        /// </param>
         /// <param name="epochLength">
         /// Length of the processing Epoch <br/>
         /// <b>Must remain constant between trials</b>
@@ -183,19 +185,15 @@ namespace BCIEssentials.LSLFramework
         /// <param name="frequencies">
         /// Collection of flashing frequencies used by stimulus objects
         /// </param>
-        /// <param name="trainingTarget">
-        /// Index of object (frequency) targetted for training <i>(0-indexed)</i>
-        /// </param>
         public SSVEPEventMarker
         (
-            int objectCount, float epochLength,
-            IEnumerable<float> frequencies,
-            int trainingTarget = -1
+            int objectCount, int trainingTarget,
+            float epochLength, IEnumerable<float> frequencies
         )
         : base
         (
-            objectCount, epochLength,
-            frequencies.ToArray(), trainingTarget
+            objectCount, trainingTarget,
+            epochLength, frequencies.ToArray()
         ) {}
     }
 
@@ -212,6 +210,9 @@ namespace BCIEssentials.LSLFramework
         /// <param name="objectCount">
         /// Number of objects (frequencies) in the trial
         /// </param>
+        /// <param name="trainingTarget">
+        /// Index of object (frequency) targetted for training <i>(0-indexed)</i>
+        /// </param>
         /// <param name="epochLength">
         /// Length of the processing Epoch <br/>
         /// <b>Must remain constant between trials</b>
@@ -219,19 +220,15 @@ namespace BCIEssentials.LSLFramework
         /// <param name="frequencies">
         /// Collection of flashing frequencies used by stimulus objects
         /// </param>
-        /// <param name="trainingTarget">
-        /// Index of object (frequency) targetted for training <i>(0-indexed)</i>
-        /// </param>
         public TVEPEventMarker
         (
-            int objectCount, float epochLength,
-            IEnumerable<float> frequencies,
-            int trainingTarget = -1
+            int objectCount, int trainingTarget,
+            float epochLength, IEnumerable<float> frequencies
         )
         : base
         (
-            objectCount, epochLength,
-            frequencies.ToArray(), trainingTarget
+            objectCount, trainingTarget,
+            epochLength, frequencies.ToArray() 
         ) {}
     }
 
@@ -273,8 +270,8 @@ namespace BCIEssentials.LSLFramework
         /// </param>
         public SingleFlashP300EventMarker
         (
-            int objectCount, int activeObject,
-            int trainingTarget = -1
+            int objectCount, int trainingTarget,
+            int activeObject
         ): base(objectCount, trainingTarget)
         {
             ActiveObject = activeObject;
@@ -300,16 +297,16 @@ namespace BCIEssentials.LSLFramework
         };
 
         /// <param name="objectCount">Number of objects in the trial</param>
-        /// <param name="activeObjects">
-        /// Collection of object indices being flashed together <i>(0-indexed)</i>
-        /// </param>
         /// <param name="trainingTarget">
         /// Index of object targetted for training <i>(0-indexed)</i>
         /// </param>
+        /// <param name="activeObjects">
+        /// Collection of object indices being flashed together <i>(0-indexed)</i>
+        /// </param>
         public MultiFlashP300EventMarker
         (
-            int objectCount, IEnumerable<int> activeObjects,
-            int trainingTarget = -1
+            int objectCount, int trainingTarget,
+            IEnumerable<int> activeObjects
         )
         : base(objectCount, trainingTarget)
         {

--- a/Runtime/Scripts/Behaviors/ContinualStimulusControllerBehavior.cs
+++ b/Runtime/Scripts/Behaviors/ContinualStimulusControllerBehavior.cs
@@ -42,13 +42,20 @@ namespace BCIEssentials.ControllerBehaviors
             while (true)
             {
                 // Send the marker
-                if (MarkerWriter != null) SendEpochMarker(trainingIndex);
+                if (MarkerWriter != null)
+                {
+                    if (TrainingRunning)
+                        SendTrainingMarker(trainingIndex);
+                    else
+                        SendClassificationMarker();
+                }
                 // Wait the epoch length + the inter-epoch interval
                 yield return new WaitForSecondsRealtime(epochLength + interEpochInterval);
             }
         }
 
-        protected abstract void SendEpochMarker(int trainingIndex = -1);
+        protected abstract void SendTrainingMarker(int trainingIndex);
+        protected abstract void SendClassificationMarker();
 
 
         protected override IEnumerator RunStimulusRoutine()

--- a/Runtime/Scripts/Behaviors/MIControllerBehavior.cs
+++ b/Runtime/Scripts/Behaviors/MIControllerBehavior.cs
@@ -111,7 +111,7 @@ namespace BCIEssentials.ControllerBehaviors
                 for (int j = 0; j < (trainingEpochCount); j++)
                 {
                     // Send the marker for the epoch
-                    MarkerWriter.PushMIMarker(1, epochLength, trainingIndex);
+                    MarkerWriter.PushMITrainingMarker(1, trainingIndex, epochLength);
 
                     yield return new WaitForSecondsRealtime(epochLength);
 
@@ -140,9 +140,10 @@ namespace BCIEssentials.ControllerBehaviors
             MarkerWriter.PushTrainingCompleteMarker();
         }
 
-        protected override void SendEpochMarker(int trainingIndex = -1)
-        {
-            MarkerWriter.PushMIMarker(SPOCount, epochLength, trainingIndex);
-        }
+        protected override void SendTrainingMarker(int trainingIndex)
+        => MarkerWriter.PushMITrainingMarker(SPOCount, trainingIndex, epochLength);
+
+        protected override void SendClassificationMarker()
+        => MarkerWriter.PushMIClassificationMarker(SPOCount, epochLength);
     }
 }

--- a/Runtime/Scripts/Behaviors/P300ControllerBehavior.cs
+++ b/Runtime/Scripts/Behaviors/P300ControllerBehavior.cs
@@ -299,9 +299,12 @@ namespace BCIEssentials.ControllerBehaviors
         {
             if (MarkerWriter != null && !blockOutGoingLSL)
             {
-                MarkerWriter.PushSingleFlashP300Marker(
-                    objectCount, flashedObjectIndex, trainTarget
-                );
+                if (TrainingRunning)
+                    MarkerWriter.PushSingleFlashP300TrainingMarker
+                    (objectCount, trainTarget, flashedObjectIndex);
+                else
+                    MarkerWriter.PushSingleFlashP300ClassificationMarker
+                    (objectCount, flashedObjectIndex);
             }
         }
 
@@ -312,10 +315,12 @@ namespace BCIEssentials.ControllerBehaviors
         {
             if (MarkerWriter != null && !blockOutGoingLSL)
             {
-                MarkerWriter.PushMultiFlashP300Marker
-                (
-                    objectCount, flashedObjectIndices, trainTarget
-                );
+                if (TrainingRunning)
+                    MarkerWriter.PushMultiFlashP300TrainingMarker
+                    (objectCount, trainTarget, flashedObjectIndices);
+                else
+                    MarkerWriter.PushMultiFlashP300ClassificationMarker
+                    (objectCount, flashedObjectIndices);
             }
         }
 

--- a/Runtime/Scripts/Behaviors/SSVEPControllerBehavior.cs
+++ b/Runtime/Scripts/Behaviors/SSVEPControllerBehavior.cs
@@ -16,10 +16,14 @@ namespace BCIEssentials.ControllerBehaviors
         private float[] realFlashingFrequencies;
 
 
-        protected override void SendEpochMarker(int trainingIndex = -1)
-        => MarkerWriter.PushSSVEPMarker(
-            SPOCount, epochLength,
-            realFlashingFrequencies, trainingIndex
+        protected override void SendTrainingMarker(int trainingIndex)
+        => MarkerWriter.PushSSVEPTrainingMarker(
+            SPOCount, trainingIndex, epochLength, realFlashingFrequencies
+        );
+
+        protected override void SendClassificationMarker()
+        => MarkerWriter.PushSSVEPClassificationMarker(
+            SPOCount, epochLength, realFlashingFrequencies
         );
 
 

--- a/Runtime/Scripts/Behaviors/SwitchControllerBehavior.cs
+++ b/Runtime/Scripts/Behaviors/SwitchControllerBehavior.cs
@@ -9,7 +9,10 @@ namespace BCIEssentials.ControllerBehaviors
     {
         public override BCIBehaviorType BehaviorType => BCIBehaviorType.Switch;
 
-        protected override void SendEpochMarker(int trainingIndex = -1)
-        => MarkerWriter.PushSwitchMarker(SPOCount, epochLength, trainingIndex);
+        protected override void SendTrainingMarker(int trainingIndex)
+        => MarkerWriter.PushSwitchTrainingMarker(SPOCount, trainingIndex, epochLength);
+
+        protected override void SendClassificationMarker()
+        => MarkerWriter.PushSwitchClassificationMarker(SPOCount, epochLength);
     }
 }

--- a/Runtime/Scripts/Behaviors/TVEPControllerBehavior.cs
+++ b/Runtime/Scripts/Behaviors/TVEPControllerBehavior.cs
@@ -18,10 +18,14 @@ namespace BCIEssentials.ControllerBehaviors
         private float realFlashingFrequency;
 
 
-        protected override void SendEpochMarker(int trainingIndex = -1)
-        => MarkerWriter.PushTVEPMarker(
-            SPOCount, epochLength,
-            new[] {realFlashingFrequency}, trainingIndex
+        protected override void SendTrainingMarker(int trainingIndex)
+        => MarkerWriter.PushTVEPTrainingMarker(
+            SPOCount, trainingIndex, epochLength, new[] {realFlashingFrequency}
+        );
+
+        protected override void SendClassificationMarker()
+        => MarkerWriter.PushTVEPClassificationMarker(
+            SPOCount, epochLength, new[] {realFlashingFrequency}
         );
 
 

--- a/Samples~/ES Stimulus Presentation/Scripts/StimulusPresentationControllerBehavior.cs
+++ b/Samples~/ES Stimulus Presentation/Scripts/StimulusPresentationControllerBehavior.cs
@@ -64,7 +64,13 @@ namespace BCIEssentials.ControllerBehaviors
             }
         }
 
-        protected override void SendEpochMarker(int trainingIndex = -1)
+        protected override void SendClassificationMarker()
+        {
+            MarkerWriter.PushSSVEPClassificationMarker
+            (SPOCount, epochLength, new[] {realFreqFlash});
+        }
+
+        protected override void SendTrainingMarker(int trainingIndex = -1)
         {
             string markerString;
                 
@@ -76,8 +82,8 @@ namespace BCIEssentials.ControllerBehaviors
             {
                 markerString = new TVEPEventMarker
                 (
-                    SPOCount, epochLength,
-                    new[] {realFreqFlash}, trainingIndex
+                    SPOCount, trainingIndex,
+                    epochLength, new[] {realFreqFlash}
                 ).MarkerString;
             }
 

--- a/Tests/Runtime/LSLFramework/LSLMarkerWriterTests.cs
+++ b/Tests/Runtime/LSLFramework/LSLMarkerWriterTests.cs
@@ -23,96 +23,96 @@ namespace BCIEssentials.Tests.LSLFramework
         }
 
         [Test]
-        [TestCase(2, 1.5f, 1, "mi,2,2,1.50")]
-        [TestCase(2, 1.5f, -1, "mi,2,-1,1.50")]
-        [TestCase(2, 2.5f, 4, "mi,2,-1,2.50")]
-        [TestCase(2, 2.5f, -2, "mi,2,-1,2.50")]
+        [TestCase(2, 1, 1.5f, "mi,2,2,1.50")]
+        [TestCase(2, -1, 1.5f, "mi,2,-1,1.50")]
+        [TestCase(2, 4, 2.5f, "mi,2,-1,2.50")]
+        [TestCase(2, -2, 2.5f, "mi,2,-1,2.50")]
         public void PushMIMarker_WhenMarkerPushed_ThenPulledWithCorrectFormat
         (
-            int objectCount, float epochLength,
-            int trainingTarget, string expectedSampleValue
+            int objectCount, int trainingTarget,
+            float epochLength, string expectedSampleValue
         )
         {
-            OutStream.PushMIMarker
+            OutStream.PushMITrainingMarker
             (
-                objectCount, epochLength, trainingTarget
+                objectCount, trainingTarget, epochLength
             );
             AssertPulledSample(expectedSampleValue);
         }
 
         [Test]
-        [TestCase(2, 1.5f, 1, "switch,2,2,1.50")]
+        [TestCase(2, 1, 1.5f, "switch,2,2,1.50")]
         public void PushSwitchMarker_WhenMarkerPushed_ThenPulledWithCorrectFormat
         (
-            int objectCount, float epochLength,
-            int trainingTarget, string expectedSampleValue
+            int objectCount, int trainingTarget,
+            float epochLength, string expectedSampleValue
         )
         {
-            OutStream.PushSwitchMarker
+            OutStream.PushSwitchTrainingMarker
             (
-                objectCount, epochLength, trainingTarget
+                objectCount, trainingTarget, epochLength
             );
             AssertPulledSample(expectedSampleValue);
         }
 
         [Test]
-        [TestCase(4, 1.5f, new[] {12.5f,18.7f,24.4f,30.1f}, 2, "ssvep,4,3,1.50,12.5,18.7,24.4,30.1")]
+        [TestCase(4, 2, 1.5f, new[] {12.5f,18.7f,24.4f,30.1f}, "ssvep,4,3,1.50,12.5,18.7,24.4,30.1")]
         public void PushSSVEPMarker_WhenMarkerPushed_ThenPulledWithCorrectFormat
         (
-            int objectCount, float epochLength, float[] frequencies,
-            int trainingTarget, string expectedSampleValue
+            int objectCount, int trainingTarget, float epochLength,
+            float[] frequencies, string expectedSampleValue
         )
         {
-            OutStream.PushSSVEPMarker
+            OutStream.PushSSVEPTrainingMarker
             (
-                objectCount, epochLength,
-                frequencies, trainingTarget
+                objectCount, trainingTarget,
+                epochLength, frequencies
             );
             AssertPulledSample(expectedSampleValue);
         }
 
         [Test]
-        [TestCase(6, 1.5f, new[] {15f}, 2, "tvep,6,3,1.50,15")]
+        [TestCase(6, 2, 1.5f, new[] {15f}, "tvep,6,3,1.50,15")]
         public void PushTVEPMarker_WhenMarkerPushed_ThenPulledWithCorrectFormat
         (
-            int objectCount, float epochLength, float[] frequencies,
-            int trainingTarget, string expectedSampleValue
+            int objectCount, int trainingTarget, float epochLength,
+            float[] frequencies, string expectedSampleValue
         )
         {
-            OutStream.PushTVEPMarker
+            OutStream.PushTVEPTrainingMarker
             (
-                objectCount, epochLength,
-                frequencies, trainingTarget
+                objectCount, trainingTarget,
+                epochLength, frequencies
             );
             AssertPulledSample(expectedSampleValue);
         }
 
         [Test]
-        [TestCase(8, 1, 3, "p300,s,8,4,2")]
+        [TestCase(8, 3, 1, "p300,s,8,4,2")]
         public void PushSingleFlashP300Marker_WhenMarkerPushed_ThenPulledWithCorrectFormat
         (
-            int objectCount, int activeObject,
-            int trainingTarget, string expectedSampleValue
+            int objectCount, int trainingTarget,
+            int activeObject, string expectedSampleValue
         )
         {
-            OutStream.PushSingleFlashP300Marker
+            OutStream.PushSingleFlashP300TrainingMarker
             (
-                objectCount, activeObject, trainingTarget
+                objectCount, trainingTarget, activeObject
             );
             AssertPulledSample(expectedSampleValue);
         }
 
         [Test]
-        [TestCase(8, new[] {1,3,5,7}, 3, "p300,m,8,4,2,4,6,8")]
+        [TestCase(8, 3, new[] {1,3,5,7}, "p300,m,8,4,2,4,6,8")]
         public void PushMultiFlashP300Marker_WhenMarkerPushed_ThenPulledWithCorrectFormat
         (
-            int objectCount, int[] activeObjects,
-            int trainingTarget, string expectedSampleValue
+            int objectCount, int trainingTarget,
+            int[] activeObjects, string expectedSampleValue
         )
         {
-            OutStream.PushMultiFlashP300Marker
+            OutStream.PushMultiFlashP300TrainingMarker
             (
-                objectCount, activeObjects, trainingTarget
+                objectCount, trainingTarget, activeObjects
             );
             AssertPulledSample(expectedSampleValue);
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.bci4kids.bciessentials",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "displayName": "BCI Essentials",
   "description": "A Unity base environment for streamlined development of BCI applications",
   "unity": "2021.3",


### PR DESCRIPTION
# Changes
- reordered event marker write helpers and class constructors to accept arguments in the same order as the formatted marker they output
- split `Push..Marker` helpers into "Training" and "Classification" variants *(specified training target or -1)*
  - *specified in docstrings when a prediction should be expected*
- split `ContinuousStimulusControllerBehaviour/SendEpochMarker()` into training and classification variants
- updated uses of `Push..Marker`
- clarified naming of Frequency stimulus markers base class
- updated tests
- updated wikis *(notably clarified the [python side](https://github.com/kirtonBCIlab/bci-essentials-python/wiki/Markers-(External-API))*

# To Validate
- check my logic on the training/classification split - does this make more sense?
- run smoke tests, make sure nothing is broken