### PR TITLE
Serial Port Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,7 @@ Follow these instructions to install BCI Essentials Unity as a package to an exi
 
 *Note - tested with Unity version 6000.3.9f1 and 2021.3.15.f1, some editor versions might not work.*
 
+## Serial Triggers
+Support for serial trigger boxes is implemented in a separate package which can be found [HERE](https://github.com/kirtonBCIlab/bci-essentials-unity-serial-triggers).
+
 [Contributing](CONTRIBUTING.md)

--- a/Runtime/Scripts/LSL/MarkerWriter.cs
+++ b/Runtime/Scripts/LSL/MarkerWriter.cs
@@ -196,7 +196,7 @@ namespace BCIEssentials.LSLFramework
         );
 
 
-        public void PushMarker(IMarker marker)
+        public virtual void PushMarker(IMarker marker)
             => PushString(marker.MarkerString);
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.bci4kids.bciessentials",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "displayName": "BCI Essentials",
   "description": "A set of front end components for streamlined development of BCI applications in Unity",
   "unity": "2021.3",


### PR DESCRIPTION
Implemented minor change necessary to append additional output methods to a marker writer, as used by the new [Serial Triggers](https://github.com/kirtonBCIlab/bci-essentials-unity-serial-triggers) package.

resolves #97 